### PR TITLE
Start fixes

### DIFF
--- a/RetroBar/App.xaml.cs
+++ b/RetroBar/App.xaml.cs
@@ -19,10 +19,12 @@ namespace RetroBar
         public ThemeManager ThemeManager { get; }
 
         private Taskbar _taskbar;
+        private readonly CloakMonitor _cloakMonitor;
         private readonly ShellManager _shellManager;
 
         public App()
         {
+            _cloakMonitor = new CloakMonitor();
             _shellManager = SetupManagedShell();
             
             ThemeManager = new ThemeManager();
@@ -43,7 +45,7 @@ namespace RetroBar
 
         private void openTaskbar()
         {
-            _taskbar = new Taskbar(_shellManager, AppBarScreen.FromPrimaryScreen(), AppBarEdge.Bottom);
+            _taskbar = new Taskbar(_shellManager, _cloakMonitor, AppBarScreen.FromPrimaryScreen(), AppBarEdge.Bottom);
             _taskbar.Show();
         }
 

--- a/RetroBar/Controls/StartButton.xaml
+++ b/RetroBar/Controls/StartButton.xaml
@@ -2,8 +2,9 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <ToggleButton ToolTip="Click here to begin"
-            Click="Button_OnClick"
+            Click="Start_OnClick"
             PreviewMouseLeftButtonDown="Start_OnPreviewMouseLeftButtonDown"
+            MouseRightButtonUp="Start_OnMouseRightButtonUp"
             Name="Start"
             Style="{DynamicResource StartButton}">
         <Grid>
@@ -17,10 +18,5 @@
                        Grid.Column="1"
                        Style="{DynamicResource StartLabel}" />
         </Grid>
-        <ToggleButton.ContextMenu>
-            <ContextMenu>
-                <MenuItem Header="Explore" Click="Explore_OnClick" />
-            </ContextMenu>
-        </ToggleButton.ContextMenu>
     </ToggleButton>
 </UserControl>

--- a/RetroBar/Controls/StartButton.xaml
+++ b/RetroBar/Controls/StartButton.xaml
@@ -1,8 +1,10 @@
 ﻿<UserControl x:Class="RetroBar.Controls.StartButton"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Button ToolTip="Click here to begin"
+    <ToggleButton ToolTip="Click here to begin"
             Click="Button_OnClick"
+            PreviewMouseLeftButtonDown="Start_OnPreviewMouseLeftButtonDown"
+            Name="Start"
             Style="{DynamicResource StartButton}">
         <Grid>
             <Grid.ColumnDefinitions>
@@ -15,10 +17,10 @@
                        Grid.Column="1"
                        Style="{DynamicResource StartLabel}" />
         </Grid>
-        <Button.ContextMenu>
+        <ToggleButton.ContextMenu>
             <ContextMenu>
                 <MenuItem Header="Explore" Click="Explore_OnClick" />
             </ContextMenu>
-        </Button.ContextMenu>
-    </Button>
+        </ToggleButton.ContextMenu>
+    </ToggleButton>
 </UserControl>

--- a/RetroBar/Controls/StartButton.xaml.cs
+++ b/RetroBar/Controls/StartButton.xaml.cs
@@ -1,5 +1,8 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Threading;
 using ManagedShell.Common.Helpers;
 
 namespace RetroBar.Controls
@@ -9,19 +12,49 @@ namespace RetroBar.Controls
     /// </summary>
     public partial class StartButton : UserControl
     {
+        private bool allowOpenStart;
+        private readonly DispatcherTimer pendingOpenTimer;
+
         public StartButton()
         {
             InitializeComponent();
+
+            pendingOpenTimer = new DispatcherTimer(DispatcherPriority.Background);
+            pendingOpenTimer.Interval = new TimeSpan(0, 0, 0, 1);
+            pendingOpenTimer.Tick += (sender, args) =>
+            {
+                // if the start menu didn't open, flip the button back to unchecked
+                Start.IsChecked = false;
+                pendingOpenTimer.Stop();
+            };
+        }
+
+        public void SetStartMenuState(bool opened)
+        {
+            Start.IsChecked = opened;
+            pendingOpenTimer.Stop();
         }
 
         private void Button_OnClick(object sender, RoutedEventArgs e)
         {
-            ShellHelper.ShowStartMenu();
+            if (allowOpenStart)
+            {
+                pendingOpenTimer.Start();
+                ShellHelper.ShowStartMenu();
+                return;
+            }
+
+            Start.IsChecked = false;
         }
 
         private void Explore_OnClick(object sender, RoutedEventArgs e)
         {
             ShellHelper.StartProcess("explorer.exe");
+        }
+
+        private void Start_OnPreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            allowOpenStart = Start.IsChecked == false;
         }
     }
 }

--- a/RetroBar/Controls/StartButton.xaml.cs
+++ b/RetroBar/Controls/StartButton.xaml.cs
@@ -35,7 +35,7 @@ namespace RetroBar.Controls
             pendingOpenTimer.Stop();
         }
 
-        private void Button_OnClick(object sender, RoutedEventArgs e)
+        private void Start_OnClick(object sender, RoutedEventArgs e)
         {
             if (allowOpenStart)
             {
@@ -47,14 +47,14 @@ namespace RetroBar.Controls
             Start.IsChecked = false;
         }
 
-        private void Explore_OnClick(object sender, RoutedEventArgs e)
-        {
-            ShellHelper.StartProcess("explorer.exe");
-        }
-
         private void Start_OnPreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
             allowOpenStart = Start.IsChecked == false;
+        }
+
+        private void Start_OnMouseRightButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            ShellHelper.ShowStartContextMenu();
         }
     }
 }

--- a/RetroBar/Controls/StartButton.xaml.cs
+++ b/RetroBar/Controls/StartButton.xaml.cs
@@ -54,7 +54,11 @@ namespace RetroBar.Controls
 
         private void Start_OnMouseRightButtonUp(object sender, MouseButtonEventArgs e)
         {
-            ShellHelper.ShowStartContextMenu();
+            if (EnvironmentHelper.IsWindows10OrBetter)
+            {
+                ShellHelper.ShowStartContextMenu();
+                e.Handled = true;
+            }
         }
     }
 }

--- a/RetroBar/RetroBar.csproj
+++ b/RetroBar/RetroBar.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.101" />
+    <PackageReference Include="ManagedShell" Version="0.0.103" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RetroBar/RetroBar.csproj
+++ b/RetroBar/RetroBar.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.99" />
+    <PackageReference Include="ManagedShell" Version="0.0.101" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RetroBar/Taskbar.xaml
+++ b/RetroBar/Taskbar.xaml
@@ -10,7 +10,8 @@
         AllowDrop="True">
     <Border>
         <DockPanel>
-            <controls:StartButton DockPanel.Dock="Left" />
+            <controls:StartButton DockPanel.Dock="Left"
+                                  x:Name="StartButton" />
             <controls:Toolbar x:Name="QuickLaunchToolbar"
                               DockPanel.Dock="Left" />
             <GroupBox DockPanel.Dock="Right"

--- a/RetroBar/Themes/System.xaml
+++ b/RetroBar/Themes/System.xaml
@@ -312,14 +312,19 @@
         </Setter>
     </Style>
 
-    <Style TargetType="Button"
-           x:Key="StartButton"
-           BasedOn="{StaticResource TaskButton}">
+    <Style TargetType="ToggleButton"
+           x:Key="StartButton">
+        <Setter Property="OverridesDefaultStyle"
+                Value="True" />
+        <Setter Property="Background"
+                Value="{DynamicResource ButtonFace}" />
+        <Setter Property="Foreground"
+                Value="{DynamicResource ButtonForeground}" />
         <Setter Property="Margin"
                 Value="0,0,2,0" />
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="Button">
+                <ControlTemplate TargetType="ToggleButton">
                     <Border Background="Transparent"
                             Padding="2">
                         <Border BorderThickness="0,0,1,1"
@@ -343,6 +348,21 @@
                         </Border>
                     </Border>
                     <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked"
+                                 Value="True">
+                            <Setter TargetName="ButtonOuterBottomBorder"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource ButtonHighlight}" />
+                            <Setter TargetName="ButtonOuterTopBorder"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource ButtonDarkShadow}" />
+                            <Setter TargetName="ButtonInnerBottomBorder"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource ButtonLight}" />
+                            <Setter TargetName="ButtonInnerTopBorder"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource ButtonShadow}" />
+                        </Trigger>
                         <Trigger Property="IsPressed"
                                  Value="True">
                             <Setter TargetName="ButtonOuterBottomBorder"

--- a/RetroBar/Themes/Watercolor.xaml
+++ b/RetroBar/Themes/Watercolor.xaml
@@ -224,14 +224,19 @@
         </Setter>
     </Style>
 
-    <Style TargetType="Button"
-           x:Key="StartButton"
-           BasedOn="{StaticResource TaskButton}">
+    <Style TargetType="ToggleButton"
+           x:Key="StartButton">
+        <Setter Property="OverridesDefaultStyle"
+                Value="True" />
+        <Setter Property="Background"
+                Value="{DynamicResource ButtonFace}" />
+        <Setter Property="Foreground"
+                Value="{DynamicResource ButtonForeground}" />
         <Setter Property="Margin"
                 Value="0,0,2,0" />
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="Button">
+                <ControlTemplate TargetType="ToggleButton">
                     <Border Background="Transparent"
                             Padding="2">
                         <Border BorderThickness="1"
@@ -265,6 +270,21 @@
                             <Setter TargetName="BottomRightBorder"
                                     Property="Background"
                                     Value="{DynamicResource StartButtonHoverBackground}" />
+                        </Trigger>
+                        <Trigger Property="IsChecked"
+                                 Value="True">
+                            <Setter TargetName="ButtonBorder"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource StartButtonPressedBorder}" />
+                            <Setter TargetName="TopLeftBorder"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource StartButtonPressedBorderShadow}" />
+                            <Setter TargetName="BottomRightBorder"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource StartButtonPressedBorderLight}" />
+                            <Setter TargetName="BottomRightBorder"
+                                    Property="Background"
+                                    Value="{DynamicResource StartButtonPressedBackground}" />
                         </Trigger>
                         <Trigger Property="IsPressed"
                                  Value="True">

--- a/RetroBar/Themes/Windows XP Blue.xaml
+++ b/RetroBar/Themes/Windows XP Blue.xaml
@@ -601,7 +601,7 @@
         </Setter>
     </Style>
 
-    <Style TargetType="Button"
+    <Style TargetType="ToggleButton"
            x:Key="StartButton">
         <Setter Property="OverridesDefaultStyle"
                 Value="True" />
@@ -615,7 +615,7 @@
                 Value="33" />
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="Button">
+                <ControlTemplate TargetType="ToggleButton">
                     <Border x:Name="StartButtonBorder">
                         <Border.Background>
                             <ImageBrush ImageSource="{DynamicResource StartButtonImage}"
@@ -633,6 +633,17 @@
                                     <ImageBrush ImageSource="{DynamicResource StartButtonImage}"
                                                 ViewboxUnits="Absolute"
                                                 Viewbox="198,0,99,33" />
+                                </Setter.Value>
+                            </Setter>
+                        </Trigger>
+                        <Trigger Property="IsChecked"
+                                 Value="True">
+                            <Setter TargetName="StartButtonBorder"
+                                    Property="Background">
+                                <Setter.Value>
+                                    <ImageBrush ImageSource="{DynamicResource StartButtonImage}"
+                                                ViewboxUnits="Absolute"
+                                                Viewbox="99,0,99,33" />
                                 </Setter.Value>
                             </Setter>
                         </Trigger>

--- a/RetroBar/Utilities/CloakMonitor.cs
+++ b/RetroBar/Utilities/CloakMonitor.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using ManagedShell.Common.Helpers;
+using ManagedShell.Interop;
+
+namespace RetroBar.Utilities
+{
+    public class CloakMonitor : IDisposable, INotifyPropertyChanged
+    {
+        const int EVENT_OBJECT_CLOAKED = 0x8017;
+
+        private IntPtr cloakEventHook;
+        private NativeMethods.WinEventProc cloakEventProc;
+        private IntPtr hwndStartMenu;
+
+        private bool _isStartMenuCloaked = true;
+
+        public bool IsStartMenuCloaked
+        {
+            get => _isStartMenuCloaked;
+            set
+            {
+                _isStartMenuCloaked = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public CloakMonitor()
+        {
+            RegisterEventHooks();
+        }
+
+        private void RegisterEventHooks()
+        {
+            if (!EnvironmentHelper.IsWindows10OrBetter) return;
+
+            hwndStartMenu = NativeMethods.FindWindow("Windows.UI.Core.CoreWindow", "Start");
+
+            if (cloakEventHook == IntPtr.Zero)
+            {
+                cloakEventProc = CloakEventCallback;
+
+                cloakEventHook = NativeMethods.SetWinEventHook(
+                    EVENT_OBJECT_CLOAKED,
+                    NativeMethods.EVENT_OBJECT_UNCLOAKED,
+                    IntPtr.Zero,
+                    cloakEventProc,
+                    0,
+                    0,
+                    NativeMethods.WINEVENT_OUTOFCONTEXT | NativeMethods.WINEVENT_SKIPOWNPROCESS);
+            }
+        }
+
+        private void CloakEventCallback(IntPtr hWinEventHook, uint eventType, IntPtr hWnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime)
+        {
+            if (hWnd != hwndStartMenu) return;
+
+            IsStartMenuCloaked = eventType == EVENT_OBJECT_CLOAKED;
+        }
+
+        public void Dispose()
+        {
+            if (cloakEventHook != IntPtr.Zero) NativeMethods.UnhookWinEvent(cloakEventHook);
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}


### PR DESCRIPTION
- Clicking start button while start menu is open correctly closes it
- Start button stays pressed when start menu is opened
  - Grace period after clicking button to prevent flicker
- Start button context menu is now the system menu
- Updated ManagedShell