### PR TITLE
Notification balloon support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ RetroBar is based on the [ManagedShell](https://github.com/cairoshell/ManagedShe
 
 ## Features
 - Replaces default Windows taskbar with classic layout
-- Native notification area
+- Native notification area with balloon notification support
 - Native task list with UWP app support
 - Quick launch toolbar
 - Start button opens modern start menu

--- a/RetroBar/Controls/NotifyBalloon.xaml
+++ b/RetroBar/Controls/NotifyBalloon.xaml
@@ -1,0 +1,27 @@
+﻿<UserControl x:Class="RetroBar.Controls.NotifyBalloon"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Popup Name="BalloonPopup"
+           IsOpen="False"
+           StaysOpen="False"
+           AllowsTransparency="True">
+        <ContentControl Style="{DynamicResource NotifyBalloon}">
+            <DockPanel>
+                <DockPanel DockPanel.Dock="Top">
+                    <Image Source="{Binding Path=Icon, Mode=OneWay}"
+                       Style="{DynamicResource NotifyBalloonIcon}"
+                       DockPanel.Dock="Left" />
+                    <TextBlock Text="{Binding Title}"
+                           Style="{DynamicResource NotifyBalloonTitle}"
+                           DockPanel.Dock="Left" />
+                    <Button Content="X"
+                        Click="Button_Click"
+                           Style="{DynamicResource NotifyBalloonCloseButton}"
+                        DockPanel.Dock="Right" />
+                </DockPanel>
+                <TextBlock Text="{Binding Info}"
+                       Style="{DynamicResource NotifyBalloonInfo}" />
+            </DockPanel>
+        </ContentControl>
+    </Popup>
+</UserControl>

--- a/RetroBar/Controls/NotifyBalloon.xaml
+++ b/RetroBar/Controls/NotifyBalloon.xaml
@@ -3,25 +3,27 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Popup Name="BalloonPopup"
            IsOpen="False"
-           StaysOpen="False"
-           AllowsTransparency="True">
-        <ContentControl Style="{DynamicResource NotifyBalloon}">
-            <DockPanel>
-                <DockPanel DockPanel.Dock="Top">
+           Style="{DynamicResource NotifyBalloonPopup}">
+        <ContentControl Style="{DynamicResource NotifyBalloon}"
+                        MouseLeftButtonUp="ContentControl_MouseLeftButtonUp"
+                        MouseRightButtonUp="ContentControl_MouseRightButtonUp">
+            <StackPanel Orientation="Vertical">
+                <DockPanel>
                     <Image Source="{Binding Path=Icon, Mode=OneWay}"
-                       Style="{DynamicResource NotifyBalloonIcon}"
-                       DockPanel.Dock="Left" />
-                    <TextBlock Text="{Binding Title}"
-                           Style="{DynamicResource NotifyBalloonTitle}"
+                           Style="{DynamicResource NotifyBalloonIcon}"
                            DockPanel.Dock="Left" />
-                    <Button Content="X"
-                        Click="Button_Click"
-                           Style="{DynamicResource NotifyBalloonCloseButton}"
-                        DockPanel.Dock="Right" />
+                    <TextBlock Text="{Binding Title}"
+                               Style="{DynamicResource NotifyBalloonTitle}"
+                               DockPanel.Dock="Left" />
+                    <Button Content="&#x72;"
+                            Click="Button_Click"
+                            Style="{DynamicResource NotifyBalloonCloseButton}"
+                            ToolTip="{DynamicResource close_tip}"
+                            DockPanel.Dock="Right" />
                 </DockPanel>
                 <TextBlock Text="{Binding Info}"
-                       Style="{DynamicResource NotifyBalloonInfo}" />
-            </DockPanel>
+                           Style="{DynamicResource NotifyBalloonInfo}" />
+            </StackPanel>
         </ContentControl>
     </Popup>
 </UserControl>

--- a/RetroBar/Controls/NotifyBalloon.xaml.cs
+++ b/RetroBar/Controls/NotifyBalloon.xaml.cs
@@ -1,4 +1,6 @@
-﻿using ManagedShell.WindowsTray;
+﻿using ManagedShell.AppBar;
+using ManagedShell.WindowsTray;
+using RetroBar.Utilities;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -17,6 +19,8 @@ namespace RetroBar.Controls
         {
             DataContext = new NotificationBalloon();
             InitializeComponent();
+
+            // TODO: Find way to promote ballooned icons while hidden
         }
 
         public void Show(NotificationBalloon balloonInfo, UIElement placementTarget)
@@ -35,17 +39,29 @@ namespace RetroBar.Controls
 
         public CustomPopupPlacement[] PlacePopup(Size popupSize, Size targetSize, Point offset)
         {
-            CustomPopupPlacement placement = new CustomPopupPlacement(new Point((popupSize.Width * -1) + offset.X,
-                (popupSize.Height * -1) + offset.Y),
-                PopupPrimaryAxis.Horizontal);
-            CustomPopupPlacement placement2 = new CustomPopupPlacement(new Point(offset.X,
-                (popupSize.Height * -1) + offset.Y),
-                PopupPrimaryAxis.Horizontal);
-            CustomPopupPlacement placement3 = new CustomPopupPlacement(new Point((popupSize.Width * -1) + offset.X,
-                targetSize.Height + offset.Y),
-                PopupPrimaryAxis.Horizontal);
+            CustomPopupPlacement placement;
 
-            return new CustomPopupPlacement[] { placement, placement2, placement3 };
+            switch ((AppBarEdge)Settings.Instance.Edge)
+            {
+                case AppBarEdge.Top:
+                    placement = new CustomPopupPlacement(new Point((popupSize.Width * -1) + offset.X,
+                        targetSize.Height + offset.Y),
+                        PopupPrimaryAxis.Horizontal);
+                    break;
+                case AppBarEdge.Left:
+                    placement = new CustomPopupPlacement(new Point(offset.X,
+                        (popupSize.Height * -1) + offset.Y),
+                        PopupPrimaryAxis.Horizontal);
+                    break;
+                default:
+                    // bottom or right taskbar
+                    placement = new CustomPopupPlacement(new Point((popupSize.Width * -1) + offset.X,
+                        (popupSize.Height * -1) + offset.Y),
+                        PopupPrimaryAxis.Horizontal);
+                    break;
+            }
+
+            return new CustomPopupPlacement[] { placement };
         }
 
         private void Button_Click(object sender, RoutedEventArgs e)
@@ -82,12 +98,14 @@ namespace RetroBar.Controls
 
         private void ContentControl_MouseRightButtonUp(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
+            // Prevent taskbar context menu from appearing
             e.Handled = true;
         }
 
         private void ContentControl_MouseLeftButtonUp(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
             (DataContext as NotificationBalloon).Click();
+
             closeBalloon();
             e.Handled = true;
         }

--- a/RetroBar/Controls/NotifyBalloon.xaml.cs
+++ b/RetroBar/Controls/NotifyBalloon.xaml.cs
@@ -4,6 +4,7 @@ using RetroBar.Utilities;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Media;
 using System.Windows.Threading;
 
 namespace RetroBar.Controls
@@ -39,22 +40,24 @@ namespace RetroBar.Controls
         {
             CustomPopupPlacement placement;
 
+            DpiScale dpiScale = VisualTreeHelper.GetDpi(this);
+
             switch ((AppBarEdge)Settings.Instance.Edge)
             {
                 case AppBarEdge.Top:
-                    placement = new CustomPopupPlacement(new Point((popupSize.Width * -1) + offset.X,
-                        targetSize.Height + offset.Y),
+                    placement = new CustomPopupPlacement(new Point((popupSize.Width * -1) + (offset.X * dpiScale.DpiScaleX),
+                        targetSize.Height + (offset.Y * dpiScale.DpiScaleY)),
                         PopupPrimaryAxis.Horizontal);
                     break;
                 case AppBarEdge.Left:
-                    placement = new CustomPopupPlacement(new Point(offset.X,
-                        (popupSize.Height * -1) + offset.Y),
+                    placement = new CustomPopupPlacement(new Point(offset.X * dpiScale.DpiScaleX,
+                        (popupSize.Height * -1) + (offset.Y * dpiScale.DpiScaleY)),
                         PopupPrimaryAxis.Horizontal);
                     break;
                 default:
                     // bottom or right taskbar
-                    placement = new CustomPopupPlacement(new Point((popupSize.Width * -1) + offset.X,
-                        (popupSize.Height * -1) + offset.Y),
+                    placement = new CustomPopupPlacement(new Point((popupSize.Width * -1) + (offset.X * dpiScale.DpiScaleX),
+                        (popupSize.Height * -1) + (offset.Y * dpiScale.DpiScaleY)),
                         PopupPrimaryAxis.Horizontal);
                     break;
             }

--- a/RetroBar/Controls/NotifyBalloon.xaml.cs
+++ b/RetroBar/Controls/NotifyBalloon.xaml.cs
@@ -19,8 +19,6 @@ namespace RetroBar.Controls
         {
             DataContext = new NotificationBalloon();
             InitializeComponent();
-
-            // TODO: Find way to promote ballooned icons while hidden
         }
 
         public void Show(NotificationBalloon balloonInfo, UIElement placementTarget)

--- a/RetroBar/Controls/NotifyBalloon.xaml.cs
+++ b/RetroBar/Controls/NotifyBalloon.xaml.cs
@@ -1,0 +1,57 @@
+﻿using ManagedShell.WindowsTray;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+
+namespace RetroBar.Controls
+{
+    /// <summary>
+    /// Interaction logic for NotifyBalloon.xaml
+    /// </summary>
+    public partial class NotifyBalloon : UserControl
+    {
+        private DispatcherTimer closeTimer;
+
+        public NotifyBalloon()
+        {
+            InitializeComponent();
+        }
+
+        public void Show(NotificationBalloonInfo balloonInfo)
+        {
+            DataContext = balloonInfo;
+            BalloonPopup.IsOpen = true;
+
+            startTimer(balloonInfo.Timeout);
+        }
+
+        private void Button_Click(object sender, RoutedEventArgs e)
+        {
+            closeBalloon();
+        }
+
+        private void closeBalloon()
+        {
+            closeTimer?.Stop();
+            BalloonPopup.IsOpen = false;
+        }
+
+        private void startTimer(int timeout)
+        {
+            closeTimer?.Stop();
+
+            closeTimer = new DispatcherTimer
+            {
+                Interval = System.TimeSpan.FromMilliseconds(timeout)
+            };
+
+            closeTimer.Tick += CloseTimer_Tick;
+            closeTimer.Start();
+        }
+
+        private void CloseTimer_Tick(object sender, System.EventArgs e)
+        {
+            closeBalloon();
+        }
+    }
+}

--- a/RetroBar/Controls/NotifyIcon.xaml
+++ b/RetroBar/Controls/NotifyIcon.xaml
@@ -1,15 +1,21 @@
 ﻿<UserControl x:Class="RetroBar.Controls.NotifyIcon"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             Loaded="NotifyIcon_OnLoaded">
-    <Border ToolTip="{Binding Path=Title}"
-            MouseUp="NotifyIcon_OnMouseUp"
-            MouseDown="NotifyIcon_OnMouseDown"
-            MouseEnter="NotifyIcon_OnMouseEnter"
-            MouseLeave="NotifyIcon_OnMouseLeave"
-            MouseMove="NotifyIcon_OnMouseMove">
-        <Image Source="{Binding Path=Icon, Mode=OneWay}"
-               Focusable="True"
-               Style="{DynamicResource NotifyIcon}" />
-    </Border>
+             xmlns:local="clr-namespace:RetroBar.Controls"
+             Loaded="NotifyIcon_OnLoaded"
+             Unloaded="NotifyIcon_OnUnloaded">
+    <StackPanel>
+        <Border x:Name="NotifyIconBorder"
+                ToolTip="{Binding Path=Title}"
+                MouseUp="NotifyIcon_OnMouseUp"
+                MouseDown="NotifyIcon_OnMouseDown"
+                MouseEnter="NotifyIcon_OnMouseEnter"
+                MouseLeave="NotifyIcon_OnMouseLeave"
+                MouseMove="NotifyIcon_OnMouseMove">
+            <Image Source="{Binding Path=Icon, Mode=OneWay}"
+                   Focusable="True"
+                   Style="{DynamicResource NotifyIcon}" />
+        </Border>
+        <local:NotifyBalloon x:Name="BalloonControl" />
+    </StackPanel>
 </UserControl>

--- a/RetroBar/Controls/NotifyIcon.xaml.cs
+++ b/RetroBar/Controls/NotifyIcon.xaml.cs
@@ -2,7 +2,6 @@
 using System.Windows.Controls;
 using System.Windows.Input;
 using ManagedShell.Common.Helpers;
-using ManagedShell.Common.Logging;
 using ManagedShell.Interop;
 
 namespace RetroBar.Controls
@@ -25,6 +24,12 @@ namespace RetroBar.Controls
             if (!isLoaded)
             {
                 TrayIcon = DataContext as ManagedShell.WindowsTray.NotifyIcon;
+
+                if (TrayIcon == null)
+                {
+                    return;
+                }
+
                 TrayIcon.NotificationBalloonShown += TrayIcon_NotificationBalloonShown;
 
                 isLoaded = true;
@@ -33,19 +38,16 @@ namespace RetroBar.Controls
 
         private void NotifyIcon_OnUnloaded(object sender, RoutedEventArgs e)
         {
-            TrayIcon.NotificationBalloonShown -= TrayIcon_NotificationBalloonShown;
+            if (TrayIcon != null)
+            {
+                TrayIcon.NotificationBalloonShown -= TrayIcon_NotificationBalloonShown;
+            }
             isLoaded = false;
         }
 
         private void TrayIcon_NotificationBalloonShown(object sender, ManagedShell.WindowsTray.NotificationBalloonEventArgs e)
         {
-            BalloonControl.BalloonPopup.PlacementTarget = NotifyIconBorder;
-            BalloonControl.BalloonPopup.Placement = System.Windows.Controls.Primitives.PlacementMode.RelativePoint;
-            BalloonControl.BalloonPopup.HorizontalOffset = 0;
-            BalloonControl.BalloonPopup.VerticalOffset = 0;
-            BalloonControl.Show(e.BalloonInfo);
-
-            ShellLogger.Debug($"{e.BalloonInfo.Title}: {e.BalloonInfo.Info}");
+            BalloonControl.Show(e.Balloon, NotifyIconBorder);
         }
 
         private void NotifyIcon_OnMouseDown(object sender, MouseButtonEventArgs e)

--- a/RetroBar/Controls/NotifyIcon.xaml.cs
+++ b/RetroBar/Controls/NotifyIcon.xaml.cs
@@ -1,8 +1,11 @@
-﻿using System.Windows;
+﻿using System;
+using System.Linq;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using ManagedShell.Common.Helpers;
 using ManagedShell.Interop;
+using ManagedShell.WindowsTray;
 
 namespace RetroBar.Controls
 {
@@ -32,6 +35,15 @@ namespace RetroBar.Controls
 
                 TrayIcon.NotificationBalloonShown += TrayIcon_NotificationBalloonShown;
 
+                // If a notification was received before we started listening, it will be here. Show the first one that is not expired.
+                NotificationBalloon firstUnexpiredNotification = TrayIcon.MissedNotifications.FirstOrDefault(balloon => balloon.Received.AddMilliseconds(balloon.Timeout) > DateTime.Now);
+
+                if (firstUnexpiredNotification != null)
+                {
+                    BalloonControl.Show(firstUnexpiredNotification, NotifyIconBorder);
+                    TrayIcon.MissedNotifications.Remove(firstUnexpiredNotification);
+                }
+
                 isLoaded = true;
             }
         }
@@ -45,9 +57,10 @@ namespace RetroBar.Controls
             isLoaded = false;
         }
 
-        private void TrayIcon_NotificationBalloonShown(object sender, ManagedShell.WindowsTray.NotificationBalloonEventArgs e)
+        private void TrayIcon_NotificationBalloonShown(object sender, NotificationBalloonEventArgs e)
         {
             BalloonControl.Show(e.Balloon, NotifyIconBorder);
+            e.Handled = true;
         }
 
         private void NotifyIcon_OnMouseDown(object sender, MouseButtonEventArgs e)

--- a/RetroBar/Controls/NotifyIcon.xaml.cs
+++ b/RetroBar/Controls/NotifyIcon.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows.Controls;
 using System.Windows.Input;
 using ManagedShell.Common.Helpers;
+using ManagedShell.Common.Logging;
 using ManagedShell.Interop;
 
 namespace RetroBar.Controls
@@ -11,6 +12,7 @@ namespace RetroBar.Controls
     /// </summary>
     public partial class NotifyIcon : UserControl
     {
+        private bool isLoaded;
         private ManagedShell.WindowsTray.NotifyIcon TrayIcon;
 
         public NotifyIcon()
@@ -20,7 +22,30 @@ namespace RetroBar.Controls
 
         private void NotifyIcon_OnLoaded(object sender, RoutedEventArgs e)
         {
-            TrayIcon = DataContext as ManagedShell.WindowsTray.NotifyIcon;
+            if (!isLoaded)
+            {
+                TrayIcon = DataContext as ManagedShell.WindowsTray.NotifyIcon;
+                TrayIcon.NotificationBalloonShown += TrayIcon_NotificationBalloonShown;
+
+                isLoaded = true;
+            }
+        }
+
+        private void NotifyIcon_OnUnloaded(object sender, RoutedEventArgs e)
+        {
+            TrayIcon.NotificationBalloonShown -= TrayIcon_NotificationBalloonShown;
+            isLoaded = false;
+        }
+
+        private void TrayIcon_NotificationBalloonShown(object sender, ManagedShell.WindowsTray.NotificationBalloonEventArgs e)
+        {
+            BalloonControl.BalloonPopup.PlacementTarget = NotifyIconBorder;
+            BalloonControl.BalloonPopup.Placement = System.Windows.Controls.Primitives.PlacementMode.RelativePoint;
+            BalloonControl.BalloonPopup.HorizontalOffset = 0;
+            BalloonControl.BalloonPopup.VerticalOffset = 0;
+            BalloonControl.Show(e.BalloonInfo);
+
+            ShellLogger.Debug($"{e.BalloonInfo.Title}: {e.BalloonInfo.Info}");
         }
 
         private void NotifyIcon_OnMouseDown(object sender, MouseButtonEventArgs e)

--- a/RetroBar/Controls/NotifyIconList.xaml
+++ b/RetroBar/Controls/NotifyIconList.xaml
@@ -3,7 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:RetroBar.Controls"
              xmlns:converters="clr-namespace:RetroBar.Converters"
-             Loaded="NotifyIconList_OnLoaded">
+             Loaded="NotifyIconList_OnLoaded"
+             Unloaded="NotifyIconList_OnUnloaded">
     <UserControl.Resources>
         <ResourceDictionary>
             <converters:EdgeOrientationConverter x:Key="edgeOrientationConverter" />

--- a/RetroBar/Controls/NotifyIconList.xaml.cs
+++ b/RetroBar/Controls/NotifyIconList.xaml.cs
@@ -65,6 +65,11 @@ namespace RetroBar.Controls
                 {
                     NotifyIcons.ItemsSource = NotificationArea.PinnedIcons;
                     SetToggleVisibility();
+
+                    if (NotifyIconToggleButton.IsChecked == true)
+                    {
+                        NotifyIconToggleButton.IsChecked = false;
+                    }
                 }
                 else
                 {

--- a/RetroBar/Controls/NotifyIconList.xaml.cs
+++ b/RetroBar/Controls/NotifyIconList.xaml.cs
@@ -118,7 +118,7 @@ namespace RetroBar.Controls
 
             DispatcherTimer unpromoteTimer = new DispatcherTimer
             {
-                Interval = TimeSpan.FromMilliseconds(e.Balloon.Timeout + 250) // Keep it around for a few ms for the animation to complete
+                Interval = TimeSpan.FromMilliseconds(e.Balloon.Timeout + 500) // Keep it around for a few ms for the animation to complete
             };
             unpromoteTimer.Tick += (object sender, EventArgs e) =>
             {

--- a/RetroBar/Controls/NotifyIconList.xaml.cs
+++ b/RetroBar/Controls/NotifyIconList.xaml.cs
@@ -75,6 +75,12 @@ namespace RetroBar.Controls
             }
         }
 
+        private void NotifyIconList_OnUnloaded(object sender, RoutedEventArgs e)
+        {
+            NotificationArea.UnpinnedIcons.CollectionChanged -= UnpinnedIcons_CollectionChanged;
+            isLoaded = false;
+        }
+
         private void UnpinnedIcons_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
             SetToggleVisibility();

--- a/RetroBar/Controls/TaskList.xaml.cs
+++ b/RetroBar/Controls/TaskList.xaml.cs
@@ -97,7 +97,7 @@ namespace RetroBar.Controls
             }
 
             double margin = TaskButtonLeftMargin + TaskButtonRightMargin;
-            double maxWidth = ActualWidth / TasksList.Items.Count;
+            double maxWidth = TasksList.ActualWidth / TasksList.Items.Count;
             double defaultWidth = DefaultButtonWidth + margin;
             double minWidth = MinButtonWidth + margin;
 
@@ -111,7 +111,7 @@ namespace RetroBar.Controls
             }
             else
             {
-                ButtonWidth = Math.Floor(maxWidth) - margin;
+                ButtonWidth = Math.Floor(maxWidth);
             }
         }
     }

--- a/RetroBar/Languages/English.xaml
+++ b/RetroBar/Languages/English.xaml
@@ -47,6 +47,7 @@
 
     <s:String x:Key="show_hidden">Show hidden icons</s:String>
     <s:String x:Key="hide">Hide</s:String>
+    <s:String x:Key="close_tip">Close</s:String>
 
     <s:String x:Key="set_time">_Adjust Date/Time</s:String>
 

--- a/RetroBar/Languages/español.xaml
+++ b/RetroBar/Languages/español.xaml
@@ -47,6 +47,7 @@
 
     <s:String x:Key="show_hidden">Mostrar iconos ocultos</s:String>
     <s:String x:Key="hide">Ocultar</s:String>
+    <s:String x:Key="close_tip">Cerrar</s:String>
 
     <s:String x:Key="set_time">Ajustar _fecha y hora</s:String>
 

--- a/RetroBar/Languages/français.xaml
+++ b/RetroBar/Languages/français.xaml
@@ -31,6 +31,7 @@
 
     <s:String x:Key="show_hidden">Afficher les icônes masquées</s:String>
     <s:String x:Key="hide">Cacher</s:String>
+    <s:String x:Key="close_tip">Fermer</s:String>
 
     <s:String x:Key="set_time">Ajuster la _date/l'heure</s:String>
 </ResourceDictionary>

--- a/RetroBar/RetroBar.csproj
+++ b/RetroBar/RetroBar.csproj
@@ -72,7 +72,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.124" />
+    <PackageReference Include="ManagedShell" Version="0.0.127" />
+    <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RetroBar/RetroBar.csproj
+++ b/RetroBar/RetroBar.csproj
@@ -72,7 +72,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.*-*" />
+    <PackageReference Include="ManagedShell" Version="0.0.124" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RetroBar/RetroBar.csproj
+++ b/RetroBar/RetroBar.csproj
@@ -72,7 +72,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.119" />
+    <PackageReference Include="ManagedShell" Version="0.0.*-*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RetroBar/Themes/System.xaml
+++ b/RetroBar/Themes/System.xaml
@@ -20,6 +20,9 @@
     <SolidColorBrush x:Key="ButtonFlashingForeground" Color="{x:Static SystemColors.HighlightTextColor}" />
     <SolidColorBrush x:Key="ClockForeground" Color="{x:Static SystemColors.ControlTextColor}" />
 
+    <SolidColorBrush x:Key="ToolTipBackground" Color="{x:Static SystemColors.InfoColor}" />
+    <SolidColorBrush x:Key="ToolTipForeground" Color="{x:Static SystemColors.InfoTextColor}" />
+
     <BitmapImage x:Key="StartIconImage"
                  UriSource="../Resources/start9x.png" />
 
@@ -845,5 +848,91 @@
                 </DataTrigger.Setters>
             </DataTrigger>
         </Style.Triggers>
+    </Style>
+
+    <Style TargetType="Image"
+           x:Key="NotifyBalloonIcon"
+           BasedOn="{StaticResource TaskIcon}">
+        <Setter Property="Margin"
+                Value="0,0,8,0" />
+        <Setter Property="VerticalAlignment"
+                Value="Center" />
+    </Style>
+
+    <Style TargetType="TextBlock"
+           x:Key="NotifyBalloonTitle"
+           BasedOn="{StaticResource GlobalFonts}">
+        <Setter Property="VerticalAlignment"
+                Value="Center" />
+        <Setter Property="FontWeight"
+                Value="Bold" />
+    </Style>
+
+    <Style TargetType="TextBlock"
+           x:Key="NotifyBalloonInfo"
+           BasedOn="{StaticResource GlobalFonts}">
+        <Setter Property="Margin"
+                Value="0,4,0,0" />
+        <Setter Property="TextWrapping"
+                Value="Wrap" />
+    </Style>
+
+    <Style TargetType="Button"
+           x:Key="NotifyBalloonCloseButton"
+           BasedOn="{StaticResource GlobalFonts}">
+        <Setter Property="VerticalAlignment"
+                Value="Center" />
+        <Setter Property="Margin"
+                Value="9,0,-7,0" />
+        <Setter Property="Height"
+                Value="16" />
+        <Setter Property="Width"
+                Value="16" />
+        <Setter Property="BorderBrush"
+                Value="{DynamicResource ButtonShadow}" />
+        <Setter Property="Background"
+                Value="{DynamicResource ButtonFace}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="1"
+                            Background="{TemplateBinding Background}">
+                        <ContentPresenter />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="ContentControl"
+           x:Key="NotifyBalloon"
+           BasedOn="{StaticResource GlobalFonts}">
+        <Setter Property="Foreground"
+                Value="{DynamicResource ToolTipForeground}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ContentControl">
+                    <DockPanel>
+                        <Border BorderThickness="1"
+                                BorderBrush="{DynamicResource ToolTipForeground}"
+                                Background="{DynamicResource ToolTipBackground}"
+                                CornerRadius="6"
+                                DockPanel.Dock="Top">
+                            <ContentPresenter Margin="11,4,11,9" />
+                        </Border>
+                        <Path Stroke="{DynamicResource ToolTipForeground}"
+                              Fill="{DynamicResource ToolTipBackground}"
+                              HorizontalAlignment="Left"
+                              Width="21"
+                              Height="21"
+                              StrokeThickness="1"
+                              Margin="10,-1,0,0"
+                              Data="M 0,0 l 20,20 V 0"
+                              DockPanel.Dock="Bottom" />
+                    </DockPanel>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 </ResourceDictionary>

--- a/RetroBar/Themes/System.xaml
+++ b/RetroBar/Themes/System.xaml
@@ -863,7 +863,7 @@
         <Setter Property="AllowsTransparency"
                 Value="True" />
         <Setter Property="StaysOpen"
-                Value="False" />
+                Value="True" />
         <Setter Property="PopupAnimation"
                 Value="Fade" />
         <Setter Property="HorizontalOffset"

--- a/RetroBar/Themes/System.xaml
+++ b/RetroBar/Themes/System.xaml
@@ -850,6 +850,49 @@
         </Style.Triggers>
     </Style>
 
+    <Style TargetType="Popup"
+           x:Key="NotifyBalloonPopup">
+        <Setter Property="AllowsTransparency"
+                Value="True" />
+        <Setter Property="StaysOpen"
+                Value="False" />
+        <Setter Property="PopupAnimation"
+                Value="Fade" />
+        <Setter Property="HorizontalOffset"
+                Value="11" />
+        <Setter Property="VerticalOffset"
+                Value="5" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=AppBarEdge, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}"
+                         Value="Left">
+                <DataTrigger.Setters>
+                    <Setter Property="HorizontalOffset"
+                            Value="-1" />
+                    <Setter Property="VerticalOffset"
+                            Value="5" />
+                </DataTrigger.Setters>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Path=AppBarEdge, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}"
+                         Value="Right">
+                <DataTrigger.Setters>
+                    <Setter Property="HorizontalOffset"
+                            Value="12" />
+                    <Setter Property="VerticalOffset"
+                            Value="5" />
+                </DataTrigger.Setters>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Path=AppBarEdge, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}"
+                         Value="Top">
+                <DataTrigger.Setters>
+                    <Setter Property="HorizontalOffset"
+                            Value="11" />
+                    <Setter Property="VerticalOffset"
+                            Value="-5" />
+                </DataTrigger.Setters>
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
     <Style TargetType="Image"
            x:Key="NotifyBalloonIcon"
            BasedOn="{StaticResource TaskIcon}">
@@ -872,7 +915,7 @@
            x:Key="NotifyBalloonInfo"
            BasedOn="{StaticResource GlobalFonts}">
         <Setter Property="Margin"
-                Value="0,4,0,0" />
+                Value="0,6,0,0" />
         <Setter Property="TextWrapping"
                 Value="Wrap" />
     </Style>
@@ -880,14 +923,22 @@
     <Style TargetType="Button"
            x:Key="NotifyBalloonCloseButton"
            BasedOn="{StaticResource GlobalFonts}">
+        <Setter Property="HorizontalAlignment"
+                Value="Right" />
         <Setter Property="VerticalAlignment"
                 Value="Center" />
         <Setter Property="Margin"
-                Value="9,0,-7,0" />
+                Value="9,-2,-7,0" />
         <Setter Property="Height"
-                Value="16" />
+                Value="18" />
         <Setter Property="Width"
-                Value="16" />
+                Value="18" />
+        <Setter Property="FontFamily"
+                Value="Marlett" />
+        <Setter Property="FontSize"
+                Value="13" />
+        <Setter Property="TextOptions.TextRenderingMode"
+                Value="Aliased" />
         <Setter Property="BorderBrush"
                 Value="{DynamicResource ButtonShadow}" />
         <Setter Property="Background"
@@ -898,8 +949,19 @@
                     <Border BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="1"
                             Background="{TemplateBinding Background}">
-                        <ContentPresenter />
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"
+                                          Name="Content"
+                                          Margin="0,1,0,0"/>
                     </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsPressed"
+                                 Value="True">
+                            <Setter TargetName="Content"
+                                    Property="Margin"
+                                    Value="1,2,0,0" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -917,20 +979,64 @@
                         <Border BorderThickness="1"
                                 BorderBrush="{DynamicResource ToolTipForeground}"
                                 Background="{DynamicResource ToolTipBackground}"
-                                CornerRadius="6"
-                                DockPanel.Dock="Top">
-                            <ContentPresenter Margin="11,4,11,9" />
+                                CornerRadius="8"
+                                RenderOptions.EdgeMode="Aliased"
+                                DockPanel.Dock="Top"
+                                Name="Border">
+                            <ContentPresenter Margin="11,6,11,9" />
                         </Border>
                         <Path Stroke="{DynamicResource ToolTipForeground}"
                               Fill="{DynamicResource ToolTipBackground}"
-                              HorizontalAlignment="Left"
+                              HorizontalAlignment="Right"
                               Width="21"
                               Height="21"
                               StrokeThickness="1"
-                              Margin="10,-1,0,0"
+                              Margin="13,-1,13,0"
                               Data="M 0,0 l 20,20 V 0"
-                              DockPanel.Dock="Bottom" />
+                              DockPanel.Dock="Bottom"
+                              RenderOptions.EdgeMode="Aliased"
+                              Visibility="Visible"
+                              Name="BottomArrow" />
+                        <Path Stroke="{DynamicResource ToolTipForeground}"
+                              Fill="{DynamicResource ToolTipBackground}"
+                              HorizontalAlignment="Right"
+                              Width="21"
+                              Height="21"
+                              StrokeThickness="1"
+                              Margin="13,0,13,-2"
+                              Data="M 0,20 l 20,-20 v 20"
+                              DockPanel.Dock="Top"
+                              RenderOptions.EdgeMode="Aliased"
+                              Visibility="Collapsed"
+                              Name="TopArrow" />
                     </DockPanel>
+                    <ControlTemplate.Triggers>
+                        <DataTrigger Binding="{Binding Path=AppBarEdge, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}"
+                                     Value="Left">
+                            <DataTrigger.Setters>
+                                <Setter TargetName="BottomArrow"
+                                        Property="Data"
+                                        Value="M 0,0 V 20 l 20,-20" />
+                                <Setter TargetName="BottomArrow"
+                                        Property="HorizontalAlignment"
+                                        Value="Left" />
+                            </DataTrigger.Setters>
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Path=AppBarEdge, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}"
+                                     Value="Top">
+                            <DataTrigger.Setters>
+                                <Setter TargetName="BottomArrow"
+                                        Property="Visibility"
+                                        Value="Collapsed" />
+                                <Setter TargetName="TopArrow"
+                                        Property="Visibility"
+                                        Value="Visible" />
+                                <Setter TargetName="Border"
+                                        Property="DockPanel.Dock"
+                                        Value="Bottom" />
+                            </DataTrigger.Setters>
+                        </DataTrigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/RetroBar/Themes/System.xaml
+++ b/RetroBar/Themes/System.xaml
@@ -52,6 +52,14 @@
     <Style TargetType="ToolTip"
            x:Key="{x:Type ToolTip}"
            BasedOn="{StaticResource GlobalFonts}">
+        <Setter Property="Background"
+                Value="{DynamicResource ToolTipBackground}" />
+        <Setter Property="Foreground"
+                Value="{DynamicResource ToolTipForeground}" />
+        <Setter Property="BorderBrush"
+                Value="{DynamicResource ToolTipForeground}" />
+        <Setter Property="Padding"
+                Value="2,1,2,1" />
     </Style>
 
     <Style TargetType="ContextMenu"
@@ -862,6 +870,8 @@
                 Value="11" />
         <Setter Property="VerticalOffset"
                 Value="5" />
+        <Setter Property="MaxWidth"
+                Value="300" />
         <Style.Triggers>
             <DataTrigger Binding="{Binding Path=AppBarEdge, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}"
                          Value="Left">
@@ -909,6 +919,8 @@
                 Value="Center" />
         <Setter Property="FontWeight"
                 Value="Bold" />
+        <Setter Property="TextWrapping"
+                Value="Wrap" />
     </Style>
 
     <Style TargetType="TextBlock"
@@ -928,7 +940,7 @@
         <Setter Property="VerticalAlignment"
                 Value="Center" />
         <Setter Property="Margin"
-                Value="9,-2,-7,0" />
+                Value="9,-4,-7,0" />
         <Setter Property="Height"
                 Value="18" />
         <Setter Property="Width"
@@ -980,7 +992,6 @@
                                 BorderBrush="{DynamicResource ToolTipForeground}"
                                 Background="{DynamicResource ToolTipBackground}"
                                 CornerRadius="8"
-                                RenderOptions.EdgeMode="Aliased"
                                 DockPanel.Dock="Top"
                                 Name="Border">
                             <ContentPresenter Margin="11,6,11,9" />
@@ -996,28 +1007,16 @@
                               DockPanel.Dock="Bottom"
                               RenderOptions.EdgeMode="Aliased"
                               Visibility="Visible"
-                              Name="BottomArrow" />
-                        <Path Stroke="{DynamicResource ToolTipForeground}"
-                              Fill="{DynamicResource ToolTipBackground}"
-                              HorizontalAlignment="Right"
-                              Width="21"
-                              Height="21"
-                              StrokeThickness="1"
-                              Margin="13,0,13,-2"
-                              Data="M 0,20 l 20,-20 v 20"
-                              DockPanel.Dock="Top"
-                              RenderOptions.EdgeMode="Aliased"
-                              Visibility="Collapsed"
-                              Name="TopArrow" />
+                              Name="Arrow" />
                     </DockPanel>
                     <ControlTemplate.Triggers>
                         <DataTrigger Binding="{Binding Path=AppBarEdge, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}"
                                      Value="Left">
                             <DataTrigger.Setters>
-                                <Setter TargetName="BottomArrow"
+                                <Setter TargetName="Arrow"
                                         Property="Data"
                                         Value="M 0,0 V 20 l 20,-20" />
-                                <Setter TargetName="BottomArrow"
+                                <Setter TargetName="Arrow"
                                         Property="HorizontalAlignment"
                                         Value="Left" />
                             </DataTrigger.Setters>
@@ -1025,15 +1024,18 @@
                         <DataTrigger Binding="{Binding Path=AppBarEdge, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}"
                                      Value="Top">
                             <DataTrigger.Setters>
-                                <Setter TargetName="BottomArrow"
-                                        Property="Visibility"
-                                        Value="Collapsed" />
-                                <Setter TargetName="TopArrow"
-                                        Property="Visibility"
-                                        Value="Visible" />
                                 <Setter TargetName="Border"
                                         Property="DockPanel.Dock"
                                         Value="Bottom" />
+                                <Setter TargetName="Arrow"
+                                        Property="Data"
+                                        Value="M 0,20 l 20,-20 v 20" />
+                                <Setter TargetName="Arrow"
+                                        Property="DockPanel.Dock"
+                                        Value="Top" />
+                                <Setter TargetName="Arrow"
+                                        Property="Margin"
+                                        Value="13,0,13,-2" />
                             </DataTrigger.Setters>
                         </DataTrigger>
                     </ControlTemplate.Triggers>

--- a/RetroBar/Themes/Watercolor.xaml
+++ b/RetroBar/Themes/Watercolor.xaml
@@ -54,6 +54,9 @@
     <SolidColorBrush x:Key="ButtonPressedForeground" Color="#ffffff" />
     <SolidColorBrush x:Key="ClockForeground" Color="#000000" />
 
+    <SolidColorBrush x:Key="ToolTipBackground" Color="#FFFFE1" />
+    <SolidColorBrush x:Key="ToolTipForeground" Color="#000000" />
+
     <FontFamily x:Key="GlobalFontFamily">Tahoma</FontFamily>
 
     <Style TargetType="ContentControl"

--- a/RetroBar/Themes/Windows 2000.xaml
+++ b/RetroBar/Themes/Windows 2000.xaml
@@ -11,5 +11,8 @@
     <SolidColorBrush x:Key="ButtonFlashingForeground" Color="#FFFFFF" />
     <SolidColorBrush x:Key="ClockForeground" Color="#000000" />
 
+    <SolidColorBrush x:Key="ToolTipBackground" Color="#FFFFE1" />
+    <SolidColorBrush x:Key="ToolTipForeground" Color="#000000" />
+
     <FontFamily x:Key="GlobalFontFamily">Tahoma</FontFamily>
 </ResourceDictionary>

--- a/RetroBar/Themes/Windows 95-98.xaml
+++ b/RetroBar/Themes/Windows 95-98.xaml
@@ -10,6 +10,9 @@
     <SolidColorBrush x:Key="ButtonForeground" Color="#000000" />
     <SolidColorBrush x:Key="ButtonFlashingForeground" Color="#FFFFFF" />
     <SolidColorBrush x:Key="ClockForeground" Color="#000000" />
+    
+    <SolidColorBrush x:Key="ToolTipBackground" Color="#FFFFE1" />
+    <SolidColorBrush x:Key="ToolTipForeground" Color="#000000" />
 
     <ToolTip x:Key="StartButtonTip" Content="{DynamicResource start_button_tip_98}" />
 

--- a/RetroBar/Themes/Windows Me.xaml
+++ b/RetroBar/Themes/Windows Me.xaml
@@ -11,5 +11,8 @@
     <SolidColorBrush x:Key="ButtonFlashingForeground" Color="#FFFFFF" />
     <SolidColorBrush x:Key="ClockForeground" Color="#000000" />
 
+    <SolidColorBrush x:Key="ToolTipBackground" Color="#FFFFE1" />
+    <SolidColorBrush x:Key="ToolTipForeground" Color="#000000" />
+
     <FontFamily x:Key="GlobalFontFamily">Microsoft Sans Serif</FontFamily>
 </ResourceDictionary>

--- a/RetroBar/Themes/Windows XP Blue.xaml
+++ b/RetroBar/Themes/Windows XP Blue.xaml
@@ -241,6 +241,53 @@
     <SolidColorBrush x:Key="ButtonFlashingForeground" Color="#ffffff" />
     <SolidColorBrush x:Key="ClockForeground" Color="#ffffff" />
 
+    <SolidColorBrush x:Key="ToolTipBackground" Color="#FFFFE1" />
+    <SolidColorBrush x:Key="ToolTipForeground" Color="#000000" />
+
+    <SolidColorBrush x:Key="BalloonCloseButtonInactiveBackground" Color="#FFFFF5" />
+    <SolidColorBrush x:Key="BalloonCloseButtonInactiveBorder" Color="#C7BEA6" />
+    <SolidColorBrush x:Key="BalloonCloseButtonInactiveForeground" Color="#AA9C87" />
+    <SolidColorBrush x:Key="BalloonCloseButtonInactiveShadow" Color="Transparent" />
+
+    <SolidColorBrush x:Key="BalloonCloseButtonActiveBorder" Color="#FFFFFF" />
+    <SolidColorBrush x:Key="BalloonCloseButtonActiveForeground" Color="#FFFFFF" />
+    <SolidColorBrush x:Key="BalloonCloseButtonActiveShadowLight" Color="#F3F3D6" />
+    <SolidColorBrush x:Key="BalloonCloseButtonActiveShadowDark" Color="#B8B8A2" />
+
+    <SolidColorBrush x:Key="BalloonCloseButtonHoverInnerLight" Color="#11000000" />
+    <SolidColorBrush x:Key="BalloonCloseButtonHoverInnerDark" Color="#33000000" />
+
+    <RadialGradientBrush x:Key="BalloonCloseButtonHoverBackground"
+                         GradientOrigin="1.0,1.0"
+                         RadiusX="0.8"
+                         RadiusY="0.8">
+        <GradientStop Color="#ffde17"
+                      Offset="0.0" />
+        <GradientStop Color="#ffad31"
+                      Offset="0.5" />
+        <GradientStop Color="#ffad31"
+                      Offset="0.6" />
+        <GradientStop Color="#ffd9a1"
+                      Offset="1.0" />
+    </RadialGradientBrush>
+
+    <SolidColorBrush x:Key="BalloonCloseButtonPressedInnerLight" Color="#08000000" />
+    <SolidColorBrush x:Key="BalloonCloseButtonPressedInnerDark" Color="#33000000" />
+
+    <RadialGradientBrush x:Key="BalloonCloseButtonPressedBackground"
+                         GradientOrigin="1.0,1.0"
+                         RadiusX="0.8"
+                         RadiusY="0.8">
+        <GradientStop Color="#d89500"
+                      Offset="0.0" />
+        <GradientStop Color="#cc7900"
+                      Offset="0.5" />
+        <GradientStop Color="#cc7900"
+                      Offset="0.6" />
+        <GradientStop Color="#a96000"
+                      Offset="1.0" />
+    </RadialGradientBrush>
+
     <BitmapImage x:Key="StartIconImage"
                  UriSource="../Resources/startxpblue.png" />
     <BitmapImage x:Key="StartButtonImage"
@@ -1128,5 +1175,118 @@
                 </DataTrigger.Setters>
             </DataTrigger>
         </Style.Triggers>
+    </Style>
+
+    <Style TargetType="Button"
+           x:Key="NotifyBalloonCloseButton"
+           BasedOn="{StaticResource NotifyBalloonCloseButton}">
+        <Setter Property="Foreground"
+                Value="{DynamicResource BalloonCloseButtonInactiveForeground}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border BorderBrush="{DynamicResource BalloonCloseButtonInactiveShadow}"
+                            BorderThickness="0,0,1,1"
+                            CornerRadius="3"
+                            Name="BorderShadowDark">
+                        <Border BorderBrush="{DynamicResource BalloonCloseButtonInactiveShadow}"
+                                BorderThickness="1,1,0,0"
+                                CornerRadius="3"
+                                Name="BorderShadowLight">
+                            <Border BorderBrush="{DynamicResource BalloonCloseButtonInactiveBorder}"
+                                    BorderThickness="1"
+                                    CornerRadius="2"
+                                    Background="{DynamicResource BalloonCloseButtonInactiveBackground}"
+                                    Name="Border">
+                                <Border BorderBrush="{DynamicResource BalloonCloseButtonInactiveShadow}"
+                                        BorderThickness="0,0,1,1"
+                                        CornerRadius="2"
+                                        Name="BorderInnerDark">
+                                    <Border BorderBrush="{DynamicResource BalloonCloseButtonInactiveShadow}"
+                                            BorderThickness="1"
+                                            CornerRadius="2"
+                                            Padding="3,3,0,0"
+                                            Name="BorderInnerLight">
+                                        <Grid x:Name="Content">
+                                            <Path Stroke="{TemplateBinding Foreground}"
+                                                  StrokeEndLineCap="Round"
+                                                  StrokeStartLineCap="Round"
+                                                  Width="8"
+                                                  Height="8"
+                                                  StrokeThickness="2"
+                                                  Data="M 0,0 l 6,6" />
+                                            <Path Stroke="{TemplateBinding Foreground}"
+                                                  StrokeEndLineCap="Round"
+                                                  StrokeStartLineCap="Round"
+                                                  Width="8"
+                                                  Height="8"
+                                                  StrokeThickness="2"
+                                                  Data="M 0,6 l 6,-6" />
+                                        </Grid>
+                                    </Border>
+                                </Border>
+                            </Border>
+                        </Border>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver"
+                                 Value="True">
+                            <Setter TargetName="BorderShadowDark"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource BalloonCloseButtonActiveShadowDark}" />
+                            <Setter TargetName="BorderShadowLight"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource BalloonCloseButtonActiveShadowLight}" />
+                            <Setter TargetName="Border"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource BalloonCloseButtonActiveBorder}" />
+                            <Setter TargetName="Border"
+                                    Property="Background"
+                                    Value="{DynamicResource BalloonCloseButtonHoverBackground}" />
+                            <Setter TargetName="BorderInnerDark"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource BalloonCloseButtonHoverInnerDark}" />
+                            <Setter TargetName="BorderInnerLight"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource BalloonCloseButtonHoverInnerLight}" />
+                            <Setter Property="Foreground"
+                                    Value="{DynamicResource BalloonCloseButtonActiveForeground}" />
+                        </Trigger>
+                        <Trigger Property="IsPressed"
+                                 Value="True">
+                            <Setter TargetName="BorderShadowDark"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource BalloonCloseButtonActiveShadowDark}" />
+                            <Setter TargetName="BorderShadowLight"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource BalloonCloseButtonActiveShadowLight}" />
+                            <Setter TargetName="Border"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource BalloonCloseButtonActiveBorder}" />
+                            <Setter TargetName="Border"
+                                    Property="Background"
+                                    Value="{DynamicResource BalloonCloseButtonPressedBackground}" />
+                            <Setter TargetName="BorderInnerDark"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource BalloonCloseButtonPressedInnerDark}" />
+                            <Setter TargetName="BorderInnerLight"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource BalloonCloseButtonPressedInnerLight}" />
+                            <Setter TargetName="BorderInnerDark"
+                                    Property="BorderThickness"
+                                    Value="1,1,0,0" />
+                            <Setter Property="Foreground"
+                                    Value="{DynamicResource BalloonCloseButtonActiveForeground}" />
+                            <Setter TargetName="Content"
+                                    Property="Opacity"
+                                    Value="0.5" />
+                            <Setter TargetName="Content"
+                                    Property="Margin"
+                                    Value="-1,-1,0,0" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 </ResourceDictionary>

--- a/RetroBar/Themes/Windows XP Classic.xaml
+++ b/RetroBar/Themes/Windows XP Classic.xaml
@@ -11,6 +11,9 @@
     <SolidColorBrush x:Key="ButtonFlashingForeground" Color="#FFFFFF" />
     <SolidColorBrush x:Key="ClockForeground" Color="#000000" />
 
+    <SolidColorBrush x:Key="ToolTipBackground" Color="#FFFFE1" />
+    <SolidColorBrush x:Key="ToolTipForeground" Color="#000000" />
+
     <FontFamily x:Key="GlobalFontFamily">Tahoma</FontFamily>
 
     <BitmapImage x:Key="StartIconImage"


### PR DESCRIPTION
- Adds support for classic style balloon notifications (#51)
- If notification area is collapsed, an icon displaying a balloon will be promoted
- Improved tooltip styles
- Fixed task button width calculation
- Fixed collapsed notification area state issue when changing themes