### PR TITLE
Add StartMenuMonitor

### DIFF
--- a/RetroBar/App.xaml.cs
+++ b/RetroBar/App.xaml.cs
@@ -18,7 +18,7 @@ namespace RetroBar
 
         private ManagedShellLogger _logger;
         private Taskbar _taskbar;
-        private readonly AppVisibilityHelper _appVisibilityHelper;
+        private readonly StartMenuMonitor _startMenuMonitor;
         private readonly ShellManager _shellManager;
         private readonly Updater _updater;
 
@@ -26,7 +26,7 @@ namespace RetroBar
         {
             _shellManager = SetupManagedShell();
 
-            _appVisibilityHelper = new AppVisibilityHelper(true);
+            _startMenuMonitor = new StartMenuMonitor(new AppVisibilityHelper(false));
             DictionaryManager = new DictionaryManager();
             _updater = new Updater();
         }
@@ -46,7 +46,7 @@ namespace RetroBar
 
         private void openTaskbar()
         {
-            _taskbar = new Taskbar(_shellManager, _appVisibilityHelper, _updater, AppBarScreen.FromPrimaryScreen(), (AppBarEdge)Settings.Instance.Edge);
+            _taskbar = new Taskbar(_shellManager, _startMenuMonitor, _updater, AppBarScreen.FromPrimaryScreen(), (AppBarEdge)Settings.Instance.Edge);
             _taskbar.Show();
         }
 
@@ -80,7 +80,7 @@ namespace RetroBar
         {
             DictionaryManager.Dispose();
             _shellManager.Dispose();
-            _appVisibilityHelper.Dispose();
+            _startMenuMonitor.Dispose();
             _updater.Dispose();
             _logger.Dispose();
         }

--- a/RetroBar/Controls/StartButton.xaml.cs
+++ b/RetroBar/Controls/StartButton.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;
 using ManagedShell.Common.Helpers;
+using RetroBar.Utilities;
 
 namespace RetroBar.Controls
 {
@@ -15,12 +16,12 @@ namespace RetroBar.Controls
         private bool allowOpenStart;
         private readonly DispatcherTimer pendingOpenTimer;
 
-        public static DependencyProperty AppVisibilityHelperProperty = DependencyProperty.Register("AppVisibilityHelper", typeof(AppVisibilityHelper), typeof(StartButton));
+        public static DependencyProperty StartMenuMonitorProperty = DependencyProperty.Register("StartMenuMonitor", typeof(StartMenuMonitor), typeof(StartButton));
 
-        public AppVisibilityHelper AppVisibilityHelper
+        public StartMenuMonitor StartMenuMonitor
         {
-            get { return (AppVisibilityHelper)GetValue(AppVisibilityHelperProperty); }
-            set { SetValue(AppVisibilityHelperProperty, value); }
+            get { return (StartMenuMonitor)GetValue(StartMenuMonitorProperty); }
+            set { SetValue(StartMenuMonitorProperty, value); }
         }
 
         public StartButton()
@@ -74,15 +75,15 @@ namespace RetroBar.Controls
 
         private void UserControl_Loaded(object sender, RoutedEventArgs e)
         {
-            AppVisibilityHelper.LauncherVisibilityChanged += AppVisibilityHelper_LauncherVisibilityChanged;
+            StartMenuMonitor.StartMenuVisibilityChanged += AppVisibilityHelper_StartMenuVisibilityChanged;
         }
 
         private void UserControl_Unloaded(object sender, RoutedEventArgs e)
         {
-            AppVisibilityHelper.LauncherVisibilityChanged -= AppVisibilityHelper_LauncherVisibilityChanged;
+            StartMenuMonitor.StartMenuVisibilityChanged -= AppVisibilityHelper_StartMenuVisibilityChanged;
         }
 
-        private void AppVisibilityHelper_LauncherVisibilityChanged(object? sender, ManagedShell.Common.SupportingClasses.LauncherVisibilityEventArgs e)
+        private void AppVisibilityHelper_StartMenuVisibilityChanged(object? sender, ManagedShell.Common.SupportingClasses.LauncherVisibilityEventArgs e)
         {
             SetStartMenuState(e.Visible);
         }

--- a/RetroBar/Taskbar.xaml.cs
+++ b/RetroBar/Taskbar.xaml.cs
@@ -25,7 +25,7 @@ namespace RetroBar
         private ShellManager _shellManager;
         private Updater _updater;
 
-        public Taskbar(ShellManager shellManager, AppVisibilityHelper appVisibilityHelper, Updater updater, AppBarScreen screen, AppBarEdge edge)
+        public Taskbar(ShellManager shellManager, StartMenuMonitor startMenuMonitor, Updater updater, AppBarScreen screen, AppBarEdge edge)
             : base(shellManager.AppBarManager, shellManager.ExplorerHelper, shellManager.FullScreenHelper, screen, edge, 0)
         {
             _shellManager = shellManager;
@@ -33,7 +33,7 @@ namespace RetroBar
 
             InitializeComponent();
             DataContext = _shellManager;
-            StartButton.AppVisibilityHelper = appVisibilityHelper;
+            StartButton.StartMenuMonitor = startMenuMonitor;
 
             DesiredHeight = Application.Current.FindResource("TaskbarHeight") as double? ?? 0;
             DesiredWidth = Application.Current.FindResource("TaskbarWidth") as double? ?? 0;

--- a/RetroBar/Utilities/StartMenuMonitor.cs
+++ b/RetroBar/Utilities/StartMenuMonitor.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Windows.Threading;
+using ManagedShell.Common.Helpers;
+using ManagedShell.Common.Logging;
+using ManagedShell.Common.SupportingClasses;
+using ManagedShell.Interop;
+
+namespace RetroBar.Utilities
+{
+    public class StartMenuMonitor: IDisposable
+    {
+        private AppVisibilityHelper _appVisibilityHelper;
+        private DispatcherTimer _poller;
+        private bool _isVisible;
+
+        public event EventHandler<LauncherVisibilityEventArgs> StartMenuVisibilityChanged;
+
+        public StartMenuMonitor(AppVisibilityHelper appVisibilityHelper)
+        {
+            _appVisibilityHelper = appVisibilityHelper;
+            setupPoller();
+        }
+
+        private void setupPoller()
+        {
+            if (_poller == null)
+            {
+                _poller = new DispatcherTimer
+                {
+                    Interval = TimeSpan.FromMilliseconds(100)
+                };
+
+                _poller.Tick += poller_Tick;
+            }
+
+            _poller.Start();
+        }
+
+        private void poller_Tick(object sender, EventArgs e)
+        {
+            setVisibility(EnvironmentHelper.IsWindows8OrBetter ? isStartMenuOpen8() : isStartMenuOpen7());
+
+            if (!_isVisible)
+            {
+                setVisibility(isOpenShellMenuOpen());
+            }
+        }
+
+        private void setVisibility(bool isVisible)
+        {
+            if (isVisible == _isVisible)
+            {
+                return;
+            }
+
+            _isVisible = isVisible;
+
+            LauncherVisibilityEventArgs args = new LauncherVisibilityEventArgs
+            {
+                Visible = _isVisible
+            };
+
+            StartMenuVisibilityChanged?.Invoke(this, args);
+        }
+
+        private bool isStartMenuOpen8()
+        {
+            if (_appVisibilityHelper == null)
+            {
+                ShellLogger.Error("StartMenuMonitor: AppVisibilityHelper is null");
+                return false;
+            }
+
+            return _appVisibilityHelper.IsLauncherVisible();
+        }
+
+        private bool isStartMenuOpen7()
+        {
+            return isVisibleByClass("DV2ControlHost");
+        }
+
+        private bool isOpenShellMenuOpen()
+        {
+            return isVisibleByClass("OpenShell.CMenuContainer");
+        }
+
+        private bool isVisibleByClass(string className)
+        {
+            IntPtr hStartMenu = NativeMethods.FindWindowEx(IntPtr.Zero, IntPtr.Zero, className, IntPtr.Zero);
+
+            if (hStartMenu == IntPtr.Zero)
+            {
+                return false;
+            }
+
+            return NativeMethods.IsWindowVisible(hStartMenu);
+        }
+
+        public void Dispose()
+        {
+            _poller?.Stop();
+        }
+    }
+}


### PR DESCRIPTION
Fixes start button pressed state for all supported operating systems, as well as for Open Shell Menu users. (#40, #60, #80)

Stopped using `IAppVisibilityEvents` due to system-generated exceptions when used with desktop apps. Polling `IAppVisibility` allows one set of code to support Windows 8 and up.