### PR TITLE
Update tray host position in more scenarios

### DIFF
--- a/RetroBar/Controls/StartButton.xaml.cs
+++ b/RetroBar/Controls/StartButton.xaml.cs
@@ -16,7 +16,14 @@ namespace RetroBar.Controls
         private bool allowOpenStart;
         private readonly DispatcherTimer pendingOpenTimer;
 
+        public static DependencyProperty HostProperty = DependencyProperty.Register("Host", typeof(Taskbar), typeof(StartButton));
         public static DependencyProperty StartMenuMonitorProperty = DependencyProperty.Register("StartMenuMonitor", typeof(StartMenuMonitor), typeof(StartButton));
+
+        public Taskbar Host
+        {
+            get { return (Taskbar)GetValue(HostProperty); }
+            set { SetValue(HostProperty, value); }
+        }
 
         public StartMenuMonitor StartMenuMonitor
         {
@@ -51,6 +58,7 @@ namespace RetroBar.Controls
         {
             if (allowOpenStart)
             {
+                Host?.SetTrayHost();
                 pendingOpenTimer.Start();
                 ShellHelper.ShowStartMenu();
                 return;

--- a/RetroBar/Taskbar.xaml
+++ b/RetroBar/Taskbar.xaml
@@ -8,6 +8,7 @@
         Title="{DynamicResource retrobar_title}"
         Left="0"
         LocationChanged="Taskbar_OnLocationChanged"
+        SizeChanged="Taskbar_OnSizeChanged"
         AllowDrop="True"
         Style="{DynamicResource TaskbarWindow}">
     <Window.Resources>
@@ -18,7 +19,8 @@
     </Window.Resources>
     <ContentControl Style="{DynamicResource Taskbar}">
         <DockPanel>
-            <controls:StartButton x:Name="StartButton">
+            <controls:StartButton x:Name="StartButton"
+                                  Host="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}">
                 <DockPanel.Dock>
                     <Binding Converter="{StaticResource dockOrientationConverter}"
                              ConverterParameter="leading"

--- a/RetroBar/Taskbar.xaml.cs
+++ b/RetroBar/Taskbar.xaml.cs
@@ -62,6 +62,7 @@ namespace RetroBar
 
             SetLayoutRounding();
             SetBlur(AllowsTransparency);
+            UpdateTrayPosition();
         }
         
         protected override IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
@@ -97,6 +98,14 @@ namespace RetroBar
         private void SetFontSmoothing()
         {
             VisualTextRenderingMode = Settings.Instance.AllowFontSmoothing ? TextRenderingMode.Auto : TextRenderingMode.Aliased;
+        }
+
+        private void UpdateTrayPosition()
+        {
+            if (Screen.Primary)
+            {
+                SetTrayHost();
+            }
         }
 
         private void Settings_PropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -185,6 +194,13 @@ namespace RetroBar
 
                 if (Top != desiredTop) Top = desiredTop;
             }
+
+            UpdateTrayPosition();
+        }
+
+        private void Taskbar_OnSizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            UpdateTrayPosition();
         }
 
         private void TaskManagerMenuItem_OnClick(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Whenever the primary taskbar is opened, moved, resized, or the start button clicked, update the tray host position accordingly. This fixes applications that request it outside of a notification area icon click (#159)