### PR TITLE
Allow building for x86 cpus.

### DIFF
--- a/RetroBar.sln
+++ b/RetroBar.sln
@@ -9,18 +9,24 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Debug|x64.Build.0 = Debug|Any CPU
+		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Debug|x86.ActiveCfg = Debug|x86
+		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Debug|x86.Build.0 = Debug|x86
 		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Release|x64.ActiveCfg = Release|Any CPU
 		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Release|x64.Build.0 = Release|Any CPU
+		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Release|x86.ActiveCfg = Release|x86
+		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RetroBar/RetroBar.csproj
+++ b/RetroBar/RetroBar.csproj
@@ -10,6 +10,7 @@
     <AssemblyVersion>1.0.0.8</AssemblyVersion>
     <FileVersion>1.0.0.8</FileVersion>
     <ApplicationIcon>Resources\retrobar.ico</ApplicationIcon>
+    <Platforms>AnyCPU;x86</Platforms>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
No big deal, just a project adjustment to build for x86 cpus since building for "any cpu" produces this:

![image](https://user-images.githubusercontent.com/25939765/152613210-c1e91b16-c521-456e-a7a4-d155291f9816.png)
more info: https://github.com/dotnet/sdk/issues/1906

Tested myself on an x86 VM and it worked fine after installing the 32-bit .net desktop runtime.

https://github.com/dremin/RetroBar/issues/143
https://github.com/dremin/RetroBar/issues/198