### PR TITLE
Set suggested context menu items in bold (task button)

### DIFF
--- a/RetroBar/Controls/TaskButton.xaml
+++ b/RetroBar/Controls/TaskButton.xaml
@@ -25,48 +25,48 @@
         </Grid>
         <Button.ContextMenu>
             <ContextMenu>
-                <MenuItem Header="{DynamicResource restore}" 
-                          Click="RestoreMenuItem_OnClick" 
+                <MenuItem Header="{DynamicResource restore}"
+                          Click="RestoreMenuItem_OnClick"
                           Name="RestoreMenuItem">
                     <MenuItem.Icon>
-                        <TextBlock FontFamily="Marlett" 
+                        <TextBlock FontFamily="Marlett"
                                    Text="&#x32;"
                                    HorizontalAlignment="Center"
                                    VerticalAlignment="Center" />
                     </MenuItem.Icon>
                 </MenuItem>
-                <MenuItem Header="{DynamicResource move}" 
-                          Click="MoveMenuItem_OnClick"  
+                <MenuItem Header="{DynamicResource move}"
+                          Click="MoveMenuItem_OnClick"
                           Name="MoveMenuItem" />
-                <MenuItem Header="{DynamicResource size}" 
-                          Click="SizeMenuItem_OnClick"  
+                <MenuItem Header="{DynamicResource size}"
+                          Click="SizeMenuItem_OnClick"
                           Name="SizeMenuItem" />
-                <MenuItem Header="{DynamicResource minimize}" 
-                          Click="MinimizeMenuItem_OnClick" 
+                <MenuItem Header="{DynamicResource minimize}"
+                          Click="MinimizeMenuItem_OnClick"
                           Name="MinimizeMenuItem">
                     <MenuItem.Icon>
-                        <TextBlock FontFamily="Marlett" 
+                        <TextBlock FontFamily="Marlett"
                                    Text="&#x30;"
                                    HorizontalAlignment="Center"
                                    VerticalAlignment="Center" />
                     </MenuItem.Icon>
                 </MenuItem>
-                <MenuItem Header="{DynamicResource maximize}" 
-                          Click="MaximizeMenuItem_OnClick" 
+                <MenuItem Header="{DynamicResource maximize}"
+                          Click="MaximizeMenuItem_OnClick"
                           Name="MaximizeMenuItem">
                     <MenuItem.Icon>
-                        <TextBlock FontFamily="Marlett" 
+                        <TextBlock FontFamily="Marlett"
                                    Text="&#x31;"
                                    HorizontalAlignment="Center"
                                    VerticalAlignment="Center" />
                     </MenuItem.Icon>
                 </MenuItem>
                 <Separator />
-                <MenuItem Header="{DynamicResource close}" 
-                          FontWeight="Bold"
-                          Click="CloseMenuItem_OnClick">
+                <MenuItem Header="{DynamicResource close}"
+                          Click="CloseMenuItem_OnClick"
+                          Name="CloseMenuItem">
                     <MenuItem.Icon>
-                        <TextBlock FontFamily="Marlett" 
+                        <TextBlock FontFamily="Marlett"
                                    Text="&#x72;"
                                    HorizontalAlignment="Center"
                                    VerticalAlignment="Center" />

--- a/RetroBar/Controls/TaskButton.xaml.cs
+++ b/RetroBar/Controls/TaskButton.xaml.cs
@@ -110,7 +110,16 @@ namespace RetroBar.Controls
             // disable window operations depending on current window state. originally tried implementing via bindings but found there is no notification we get regarding maximized state
             MaximizeMenuItem.IsEnabled = (wss != NativeMethods.WindowShowStyle.ShowMaximized && (ws & (int)NativeMethods.WindowStyles.WS_MAXIMIZEBOX) != 0);
             MinimizeMenuItem.IsEnabled = (wss != NativeMethods.WindowShowStyle.ShowMinimized && (ws & (int)NativeMethods.WindowStyles.WS_MINIMIZEBOX) != 0);
-            RestoreMenuItem.IsEnabled = (wss != NativeMethods.WindowShowStyle.ShowNormal);
+            if (RestoreMenuItem.IsEnabled = (wss != NativeMethods.WindowShowStyle.ShowNormal))
+            {
+                CloseMenuItem.FontWeight = FontWeights.Normal;
+                RestoreMenuItem.FontWeight = FontWeights.Bold;
+            }
+            if (!RestoreMenuItem.IsEnabled || RestoreMenuItem.IsEnabled && !MaximizeMenuItem.IsEnabled)
+            {
+                CloseMenuItem.FontWeight = FontWeights.Bold;
+                RestoreMenuItem.FontWeight = FontWeights.Normal;
+            }
             MoveMenuItem.IsEnabled = wss == NativeMethods.WindowShowStyle.ShowNormal;
             SizeMenuItem.IsEnabled = (wss == NativeMethods.WindowShowStyle.ShowNormal && (ws & (int)NativeMethods.WindowStyles.WS_MAXIMIZEBOX) != 0);
         }


### PR DESCRIPTION
When the program is minimized, the "Restore" item is bold and when it is restored, the "Close" item is the one that should be bold.
This can be added to XAML themes, but for now, it should be basic and non-theme dependent behavior.