### PR TITLE
Add ARM64 build (#66)

### DIFF
--- a/.github/workflows/retrobar.yml
+++ b/.github/workflows/retrobar.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        publishprofile: [ x64, x86 ]
+        publishprofile: [ [x64, netcoreapp3.1], [x86, netcoreapp3.1], [ARM64, net6.0-windows10.0.19041.0] ]
 
     runs-on: windows-latest
 
@@ -26,17 +26,18 @@ jobs:
       uses: dotnet/nbgv@v0.4.0
 
     - name: Publish app
-      run: dotnet publish -p:PublishProfile=$env:Profile -f netcoreapp3.1
+      run: dotnet publish -p:PublishProfile=$env:Profile -f $env:Framework
       env:
-        Profile: ${{ matrix.publishprofile }}
+        Profile: ${{ matrix.publishprofile[0] }}
+        Framework: ${{ matrix.publishprofile[1] }}
 
     - name: Copy license
-      run: cp DistLicense.txt RetroBar\bin\Release\netcoreapp3.1\publish-${{ matrix.publishprofile }}\License.txt
+      run: cp DistLicense.txt RetroBar\bin\Release\${{ matrix.publishprofile[1] }}\publish-${{ matrix.publishprofile[0] }}\License.txt
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: RetroBar ${{ matrix.publishprofile == 'x86' && '32-bit' || '64-bit' }}
+        name: RetroBar ${{ matrix.publishprofile[0] == 'x86' && '32-bit' || matrix.publishprofile[0] == 'x64' && '64-bit' || 'ARM64' }}
         path: |
-          RetroBar\bin\Release\netcoreapp3.1\publish-${{ matrix.publishprofile }}\RetroBar.exe
-          RetroBar\bin\Release\netcoreapp3.1\publish-${{ matrix.publishprofile }}\License.txt
+          RetroBar\bin\Release\${{ matrix.publishprofile[1] }}\publish-${{ matrix.publishprofile[0] }}\RetroBar.exe
+          RetroBar\bin\Release\${{ matrix.publishprofile[1] }}\publish-${{ matrix.publishprofile[0] }}\License.txt

--- a/RetroBar.sln
+++ b/RetroBar.sln
@@ -8,21 +8,27 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|ARM64 = Debug|ARM64
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|ARM64 = Release|ARM64
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Debug|ARM64.Build.0 = Debug|ARM64
 		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Debug|x64.Build.0 = Debug|Any CPU
 		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Debug|x86.ActiveCfg = Debug|x86
 		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Debug|x86.Build.0 = Debug|x86
 		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Release|ARM64.ActiveCfg = Release|ARM64
+		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Release|ARM64.Build.0 = Release|ARM64
 		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Release|x64.ActiveCfg = Release|Any CPU
 		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Release|x64.Build.0 = Release|Any CPU
 		{9D976354-1F87-415C-9AB1-5DC50350CBFC}.Release|x86.ActiveCfg = Release|x86

--- a/RetroBar/Properties/PublishProfiles/ARM64.pubxml
+++ b/RetroBar/Properties/PublishProfiles/ARM64.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>ARM64</Platform>
+    <PublishDir>bin\Release\net6.0-windows10.0.19041.0\publish-arm64</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
+  </PropertyGroup>
+</Project>

--- a/RetroBar/Properties/PublishProfiles/x64.pubxml
+++ b/RetroBar/Properties/PublishProfiles/x64.pubxml
@@ -5,7 +5,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration>Release</Configuration>
-    <Platform>Any CPU</Platform>
+    <Platform>x64</Platform>
     <PublishDir>bin\Release\netcoreapp3.1\publish-x64\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/RetroBar/RetroBar.csproj
+++ b/RetroBar/RetroBar.csproj
@@ -10,6 +10,7 @@
     <AssemblyVersion>1.0.0.8</AssemblyVersion>
     <FileVersion>1.0.0.8</FileVersion>
     <ApplicationIcon>Resources\retrobar.ico</ApplicationIcon>
+	<ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
     <Platforms>AnyCPU;x86;ARM64</Platforms>
   </PropertyGroup>
 

--- a/RetroBar/RetroBar.csproj
+++ b/RetroBar/RetroBar.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net480</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net480;net6.0-windows10.0.19041.0</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <StartupObject>RetroBar.Program</StartupObject>
@@ -10,7 +10,7 @@
     <AssemblyVersion>1.0.0.8</AssemblyVersion>
     <FileVersion>1.0.0.8</FileVersion>
     <ApplicationIcon>Resources\retrobar.ico</ApplicationIcon>
-    <Platforms>AnyCPU;x86</Platforms>
+    <Platforms>AnyCPU;x86;ARM64</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net480'">

--- a/RetroBar/RetroBar.csproj
+++ b/RetroBar/RetroBar.csproj
@@ -42,7 +42,7 @@
 
   <ItemGroup>
     <PackageReference Include="gong-wpf-dragdrop" Version="3.1.1" />
-    <PackageReference Include="ManagedShell" Version="0.0.172" />
+    <PackageReference Include="ManagedShell" Version="0.0.175" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
   </ItemGroup>
 

--- a/RetroBar/Taskbar.xaml.cs
+++ b/RetroBar/Taskbar.xaml.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using ManagedShell.AppBar;
+﻿using ManagedShell.AppBar;
 using ManagedShell.Common.Helpers;
 using ManagedShell.Interop;
 using ManagedShell;
@@ -8,7 +7,6 @@ using System;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media;
 using RetroBar.Utilities;
 using Application = System.Windows.Application;
 using RetroBar.Controls;
@@ -166,7 +164,7 @@ namespace RetroBar
             }
         }
 
-        private void Taskbar_OnLocationChanged(object? sender, EventArgs e)
+        private void Taskbar_OnLocationChanged(object sender, EventArgs e)
         {
             // primarily for win7/8, they will set up the appbar correctly but then put it in the wrong place
             if (Orientation == Orientation.Vertical)

--- a/RetroBar/app.manifest
+++ b/RetroBar/app.manifest
@@ -45,6 +45,17 @@
     </application>
   </compatibility>
 
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+  	  <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+	  <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+
   <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
   <dependency>
     <dependentAssembly>

--- a/RetroBar/app.manifest
+++ b/RetroBar/app.manifest
@@ -45,17 +45,6 @@
     </application>
   </compatibility>
 
-  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
-       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
-       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
-       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
-  <application xmlns="urn:schemas-microsoft-com:asm.v3">
-    <windowsSettings>
-      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
-    </windowsSettings>
-  </application>
-
   <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
   <dependency>
     <dependentAssembly>


### PR DESCRIPTION
Uses .NET 6 as .NET Core 3.1 does not support ARM64 on Windows.