### PR TITLE
Fix large .NET 6 builds, use .NET 6 everywhere

### DIFF
--- a/.github/workflows/retrobar.yml
+++ b/.github/workflows/retrobar.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        publishprofile: [ [x64, netcoreapp3.1], [x86, netcoreapp3.1], [ARM64, net6.0-windows10.0.19041.0] ]
+        publishprofile: [ [x64, net6.0-windows], [x86, net6.0-windows], [ARM64, net6.0-windows] ]
 
     runs-on: windows-latest
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ RetroBar is based on the [ManagedShell](https://github.com/cairoshell/ManagedShe
 
 ## Requirements
 - Windows 7 SP1, Windows 8.1, Windows 10, or Windows 11
-- [.NET Core 3.1 desktop runtime](https://dotnet.microsoft.com/download/dotnet/3.1/runtime) (select the appropriate download button under "Run desktop apps")
+- [.NET 6 desktop runtime](https://dotnet.microsoft.com/download/dotnet/6.0/runtime) (select the appropriate download button under "Run desktop apps")
 
 ## Features
 - Replaces default Windows taskbar with classic layout

--- a/RetroBar/Properties/PublishProfiles/ARM64.pubxml
+++ b/RetroBar/Properties/PublishProfiles/ARM64.pubxml
@@ -6,9 +6,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>ARM64</Platform>
-    <PublishDir>bin\Release\net6.0-windows10.0.19041.0\publish-arm64</PublishDir>
+    <PublishDir>bin\Release\net6.0-windows\publish-arm64</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>

--- a/RetroBar/Properties/PublishProfiles/x64.pubxml
+++ b/RetroBar/Properties/PublishProfiles/x64.pubxml
@@ -6,13 +6,14 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>x64</Platform>
-    <PublishDir>bin\Release\netcoreapp3.1\publish-x64\</PublishDir>
+    <PublishDir>bin\Release\net6.0-windows\publish-x64\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>True</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>
+	<IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
     <PublishTrimmed>False</PublishTrimmed>
   </PropertyGroup>
 </Project>

--- a/RetroBar/Properties/PublishProfiles/x86.pubxml
+++ b/RetroBar/Properties/PublishProfiles/x86.pubxml
@@ -6,13 +6,14 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>x86</Platform>
-    <PublishDir>bin\Release\netcoreapp3.1\publish-x86\</PublishDir>
+    <PublishDir>bin\Release\net6.0-windows\publish-x86\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>True</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>
+	<IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
     <PublishTrimmed>False</PublishTrimmed>
   </PropertyGroup>
 </Project>

--- a/RetroBar/RetroBar.csproj
+++ b/RetroBar/RetroBar.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net480;net6.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net480;net6.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <StartupObject>RetroBar.Program</StartupObject>
@@ -43,7 +43,7 @@
 
   <ItemGroup>
     <PackageReference Include="gong-wpf-dragdrop" Version="3.1.1" />
-    <PackageReference Include="ManagedShell" Version="0.0.175" />
+    <PackageReference Include="ManagedShell" Version="0.0.179" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Now that .NET 6 builds are no longer 25 MB, use it for all architectures. Theoretically this should improve performance everywhere due to optimizations made in .NET 5 and 6.

Requires cairoshell/managedshell#62; will re-run CI after that merges.