### PR TITLE
Optionally show tasks only on the same taskbar as window

### DIFF
--- a/RetroBar/App.config
+++ b/RetroBar/App.config
@@ -49,6 +49,9 @@
             <setting name="ShowTaskThumbnails" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="MultiMonMode" serializeAs="String">
+                <value>0</value>
+            </setting>
         </RetroBar.Properties.Settings>
     </userSettings>
 </configuration>

--- a/RetroBar/App.xaml.cs
+++ b/RetroBar/App.xaml.cs
@@ -107,7 +107,6 @@ namespace RetroBar
 
             ShellConfig config = ShellManager.DefaultShellConfig;
             config.PinnedNotifyIcons = Settings.Instance.PinnedNotifyIcons;
-            config.MultiMonAwareTasksService = false;
 
             return new ShellManager(config);
         }

--- a/RetroBar/Controls/TaskList.xaml.cs
+++ b/RetroBar/Controls/TaskList.xaml.cs
@@ -74,7 +74,11 @@ namespace RetroBar.Controls
             if (!isLoaded && Tasks != null)
             {
                 taskbarItems = Tasks.CreateGroupedWindowsCollection();
-                taskbarItems.Filter = Tasks_Filter;
+                if (taskbarItems != null)
+                {
+                    taskbarItems.CollectionChanged += GroupedWindows_CollectionChanged;
+                    taskbarItems.Filter = Tasks_Filter;
+                }
 
                 TasksList.ItemsSource = taskbarItems;
 
@@ -131,7 +135,10 @@ namespace RetroBar.Controls
 
         private void TaskList_OnUnloaded(object sender, RoutedEventArgs e)
         {
-            Tasks.GroupedWindows.CollectionChanged -= GroupedWindows_CollectionChanged;
+            if (taskbarItems != null)
+            {
+                taskbarItems.CollectionChanged -= GroupedWindows_CollectionChanged;
+            }
             isLoaded = false;
         }
 

--- a/RetroBar/Controls/TaskList.xaml.cs
+++ b/RetroBar/Controls/TaskList.xaml.cs
@@ -2,6 +2,7 @@
 using ManagedShell.WindowsTasks;
 using RetroBar.Utilities;
 using System;
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -18,7 +19,8 @@ namespace RetroBar.Controls
         private double MinButtonWidth;
         private double TaskButtonLeftMargin;
         private double TaskButtonRightMargin;
-        
+        private ICollectionView taskbarItems;
+
         public static DependencyProperty ButtonWidthProperty = DependencyProperty.Register("ButtonWidth", typeof(double), typeof(TaskList), new PropertyMetadata(new double()));
 
         public double ButtonWidth
@@ -33,6 +35,14 @@ namespace RetroBar.Controls
         {
             get { return (Tasks)GetValue(TasksProperty); }
             set { SetValue(TasksProperty, value); }
+        }
+
+        public static DependencyProperty HostProperty = DependencyProperty.Register("Host", typeof(Taskbar), typeof(TaskList));
+
+        public Taskbar Host
+        {
+            get { return (Taskbar)GetValue(HostProperty); }
+            set { SetValue(HostProperty, value); }
         }
 
         public TaskList()
@@ -63,14 +73,60 @@ namespace RetroBar.Controls
         {
             if (!isLoaded && Tasks != null)
             {
-                TasksList.ItemsSource = Tasks.GroupedWindows;
-                if (Tasks.GroupedWindows != null)
-                    Tasks.GroupedWindows.CollectionChanged += GroupedWindows_CollectionChanged;
-                
+                taskbarItems = Tasks.CreateGroupedWindowsCollection();
+                taskbarItems.Filter = Tasks_Filter;
+
+                TasksList.ItemsSource = taskbarItems;
+
+                Settings.Instance.PropertyChanged += Settings_PropertyChanged;
+
                 isLoaded = true;
             }
 
             SetStyles();
+        }
+
+        private void Settings_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == "MultiMonMode")
+            {
+                taskbarItems?.Refresh();
+            }
+            else if (e.PropertyName == "ShowMultiMon")
+            {
+                if (Settings.Instance.MultiMonMode != 0)
+                {
+                    taskbarItems?.Refresh();
+                }
+            }
+        }
+
+        private bool Tasks_Filter(object obj)
+        {
+            if (obj is ApplicationWindow window)
+            {
+                if (!window.ShowInTaskbar)
+                {
+                    return false;
+                }
+
+                if (!Settings.Instance.ShowMultiMon || Settings.Instance.MultiMonMode == 0)
+                {
+                    return true;
+                }
+
+                if (Settings.Instance.MultiMonMode == 2 && Host.Screen.Primary)
+                {
+                    return true;
+                }
+
+                if (window.HMonitor != Host.Screen.HMonitor)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private void TaskList_OnUnloaded(object sender, RoutedEventArgs e)

--- a/RetroBar/Languages/English.xaml
+++ b/RetroBar/Languages/English.xaml
@@ -29,6 +29,15 @@
     <s:String x:Key="quick_launch_folder">Quick Launch - Choose a folder</s:String>
     <s:String x:Key="show_window_previews">Show _window previews (thumbnails)</s:String>
     <s:String x:Key="use_software_rendering">_Use software rendering</s:String>
+    <s:String x:Key="multiple_monitors">Multiple monitors</s:String>
+    <s:String x:Key="show_tasks_on">S_how tasks on:</s:String>
+    <x:Array x:Key="show_tasks_on_values" Type="s:String">
+        <s:String>All taskbars</s:String>
+        <s:String>Same taskbar as window</s:String>
+        <s:String>Same taskbar as window and primary taskbar</s:String>
+    </x:Array>
+    <s:String x:Key="version">Version {0}</s:String>
+    <s:String x:Key="visit_on_github">Visit on GitHub</s:String>
     <s:String x:Key="ok_dialog">OK</s:String>
 
     <s:String x:Key="customize_notifications">Customize Notifications</s:String>

--- a/RetroBar/Languages/English.xaml
+++ b/RetroBar/Languages/English.xaml
@@ -29,7 +29,7 @@
     <s:String x:Key="quick_launch_folder">Quick Launch - Choose a folder</s:String>
     <s:String x:Key="show_window_previews">Show _window previews (thumbnails)</s:String>
     <s:String x:Key="use_software_rendering">_Use software rendering</s:String>
-    <s:String x:Key="multiple_monitors">Multiple monitors</s:String>
+    <s:String x:Key="multiple_displays">Multiple displays</s:String>
     <s:String x:Key="show_tasks_on">S_how tasks on:</s:String>
     <x:Array x:Key="show_tasks_on_values" Type="s:String">
         <s:String>All taskbars</s:String>

--- a/RetroBar/Properties/Settings.Designer.cs
+++ b/RetroBar/Properties/Settings.Designer.cs
@@ -191,5 +191,17 @@ namespace RetroBar.Properties {
                 this["ShowTaskThumbnails"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int MultiMonMode {
+            get {
+                return ((int)(this["MultiMonMode"]));
+            }
+            set {
+                this["MultiMonMode"] = value;
+            }
+        }
     }
 }

--- a/RetroBar/Properties/Settings.settings
+++ b/RetroBar/Properties/Settings.settings
@@ -44,5 +44,8 @@
     <Setting Name="ShowTaskThumbnails" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="MultiMonMode" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/RetroBar/PropertiesWindow.xaml
+++ b/RetroBar/PropertiesWindow.xaml
@@ -8,6 +8,7 @@
         Icon="Resources/retrobar.ico"
         Height="Auto"
         Width="Auto"
+        MinWidth="413"
         ResizeMode="NoResize"
         SizeToContent="WidthAndHeight"
         FlowDirection="{DynamicResource flow_direction}"
@@ -189,10 +190,6 @@
                             <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=AllowFontSmoothing, UpdateSourceTrigger=PropertyChanged}">
                                 <Label Content="{DynamicResource allow_font_smoothing}" />
                             </CheckBox>
-                            <CheckBox x:Name="cbShowMultiMon"
-                                      IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowMultiMon, UpdateSourceTrigger=PropertyChanged}">
-                                <Label Content="{DynamicResource show_multi_mon}" />
-                            </CheckBox>
                             <DockPanel>
                                 <CheckBox x:Name="cbShowQuickLaunch"
                                           IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowQuickLaunch, UpdateSourceTrigger=PropertyChanged}">
@@ -267,19 +264,60 @@
                             </DockPanel>
                         </StackPanel>
                     </GroupBox>
-                    <GroupBox Header="RetroBar">
+                    <GroupBox Header="{DynamicResource multiple_monitors}">
                         <StackPanel Orientation="Vertical">
-                            <CheckBox Checked="AutoStartCheckBox_OnChecked"
-                                      Unchecked="AutoStartCheckBox_OnChecked"
-                                      Name="AutoStartCheckBox">
-                                <Label Content="{DynamicResource autostart}" />
+                            <CheckBox x:Name="cbShowMultiMon"
+                                      IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowMultiMon, UpdateSourceTrigger=PropertyChanged}">
+                                <Label Content="{DynamicResource show_multi_mon}" />
                             </CheckBox>
-                            <CheckBox x:Name="cbUseSoftwareRendering"
-                                      IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=UseSoftwareRendering, UpdateSourceTrigger=PropertyChanged}">
-                                <Label Content="{DynamicResource use_software_rendering}" />
-                            </CheckBox>
+                            <DockPanel>
+                                <Label VerticalAlignment="Center"
+                                       Target="{Binding ElementName=MultiMonMode}">
+                                    <AccessText Text="{DynamicResource show_tasks_on}" />
+                                </Label>
+                                <ComboBox Name="cboMultiMonMode"
+                                          IsEnabled="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowMultiMon, UpdateSourceTrigger=PropertyChanged}"
+                                          ItemsSource="{DynamicResource show_tasks_on_values}"
+                                          SelectedIndex="{Binding Source={x:Static Settings:Settings.Instance}, Path=MultiMonMode, UpdateSourceTrigger=PropertyChanged}"
+                                          SelectionChanged="cboMultiMonMode_SelectionChanged" />
+                            </DockPanel>
                         </StackPanel>
                     </GroupBox>
+                </StackPanel>
+            </TabItem>
+            <TabItem Header="RetroBar">
+                <StackPanel Orientation="Vertical"
+                            Margin="10">
+                    <StackPanel Orientation="Vertical">
+                        <CheckBox Checked="AutoStartCheckBox_OnChecked"
+                                  Unchecked="AutoStartCheckBox_OnChecked"
+                                  Name="AutoStartCheckBox">
+                            <Label Content="{DynamicResource autostart}" />
+                        </CheckBox>
+                        <CheckBox x:Name="cbUseSoftwareRendering"
+                                  IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=UseSoftwareRendering, UpdateSourceTrigger=PropertyChanged}">
+                            <Label Content="{DynamicResource use_software_rendering}" />
+                        </CheckBox>
+                    </StackPanel>
+                    <DockPanel Margin="0,10,0,0">
+                        <StackPanel Orientation="Vertical"
+                                    DockPanel.Dock="Left"
+                                    Margin="0,0,10,0"
+                                    VerticalAlignment="Center">
+                            <TextBlock Name="txtVersion" />
+                        </StackPanel>
+                        <StackPanel Orientation="Vertical"
+                                    DockPanel.Dock="Right"
+                                    VerticalAlignment="Center">
+                            <TextBlock TextAlignment="Right">
+                                <Hyperlink NavigateUri="https://github.com/dremin/RetroBar" RequestNavigate="Hyperlink_RequestNavigate">
+                                    <Hyperlink.Inlines>
+                                        <Run Text="{DynamicResource visit_on_github}" />
+                                    </Hyperlink.Inlines>
+                                </Hyperlink>
+                            </TextBlock>
+                        </StackPanel>
+                    </DockPanel>
                 </StackPanel>
             </TabItem>
         </TabControl>

--- a/RetroBar/PropertiesWindow.xaml
+++ b/RetroBar/PropertiesWindow.xaml
@@ -264,7 +264,7 @@
                             </DockPanel>
                         </StackPanel>
                     </GroupBox>
-                    <GroupBox Header="{DynamicResource multiple_monitors}">
+                    <GroupBox Header="{DynamicResource multiple_displays}">
                         <StackPanel Orientation="Vertical">
                             <CheckBox x:Name="cbShowMultiMon"
                                       IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowMultiMon, UpdateSourceTrigger=PropertyChanged}">
@@ -272,7 +272,7 @@
                             </CheckBox>
                             <DockPanel>
                                 <Label VerticalAlignment="Center"
-                                       Target="{Binding ElementName=MultiMonMode}">
+                                       Target="{Binding ElementName=cboMultiMonMode}">
                                     <AccessText Text="{DynamicResource show_tasks_on}" />
                                 </Label>
                                 <ComboBox Name="cboMultiMonMode"
@@ -300,23 +300,18 @@
                         </CheckBox>
                     </StackPanel>
                     <DockPanel Margin="0,10,0,0">
-                        <StackPanel Orientation="Vertical"
-                                    DockPanel.Dock="Left"
-                                    Margin="0,0,10,0"
-                                    VerticalAlignment="Center">
-                            <TextBlock Name="txtVersion" />
-                        </StackPanel>
-                        <StackPanel Orientation="Vertical"
-                                    DockPanel.Dock="Right"
-                                    VerticalAlignment="Center">
-                            <TextBlock TextAlignment="Right">
-                                <Hyperlink NavigateUri="https://github.com/dremin/RetroBar" RequestNavigate="Hyperlink_RequestNavigate">
+                        <TextBlock Name="txtVersion"
+                                   DockPanel.Dock="Left"
+                                   Margin="0,0,10,0" />
+                        <TextBlock DockPanel.Dock="Right"
+                                   TextAlignment="Right">
+                                <Hyperlink NavigateUri="https://github.com/dremin/RetroBar"
+                                           RequestNavigate="Hyperlink_RequestNavigate">
                                     <Hyperlink.Inlines>
                                         <Run Text="{DynamicResource visit_on_github}" />
                                     </Hyperlink.Inlines>
                                 </Hyperlink>
-                            </TextBlock>
-                        </StackPanel>
+                        </TextBlock>
                     </DockPanel>
                 </StackPanel>
             </TabItem>

--- a/RetroBar/PropertiesWindow.xaml.cs
+++ b/RetroBar/PropertiesWindow.xaml.cs
@@ -51,6 +51,7 @@ namespace RetroBar
             LoadAutoStart();
             LoadLanguages();
             LoadThemes();
+            LoadVersion();
         }
 
         public static PropertiesWindow Open(NotificationArea notificationArea, DictionaryManager dictionaryManager, AppBarScreen screen, double dpiScale, double barSize)
@@ -107,6 +108,11 @@ namespace RetroBar
             {
                 cboThemeSelect.Items.Add(theme);
             }
+        }
+
+        private void LoadVersion()
+        {
+            txtVersion.Text = string.Format((string)FindResource("version"), System.Windows.Forms.Application.ProductVersion);
         }
 
         private void UpdateWindowPosition()
@@ -200,6 +206,14 @@ namespace RetroBar
             }
         }
 
+        private void cboMultiMonMode_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            if (cboMultiMonMode.SelectedItem == null)
+            {
+                cboMultiMonMode.SelectedValue = cboMultiMonMode.Items[Settings.Instance.MultiMonMode];
+            }
+        }
+
         private void CustomizeNotifications_OnClick(object sender, RoutedEventArgs e)
         {
             OpenCustomizeNotifications();
@@ -208,6 +222,12 @@ namespace RetroBar
         public void OpenCustomizeNotifications()
         {
             NotificationPropertiesWindow.Open(_notificationArea, new Point(Left, Top));
+        }
+
+        private void Hyperlink_RequestNavigate(object sender, System.Windows.Navigation.RequestNavigateEventArgs e)
+        {
+            ShellHelper.ExecuteProcess(e.Uri.AbsoluteUri);
+            e.Handled = true;
         }
     }
 }

--- a/RetroBar/RetroBar.csproj
+++ b/RetroBar/RetroBar.csproj
@@ -43,7 +43,7 @@
 
   <ItemGroup>
     <PackageReference Include="gong-wpf-dragdrop" Version="3.1.1" />
-    <PackageReference Include="ManagedShell" Version="0.0.196" />
+    <PackageReference Include="ManagedShell" Version="0.0.198" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
   </ItemGroup>
 

--- a/RetroBar/Taskbar.xaml
+++ b/RetroBar/Taskbar.xaml
@@ -76,6 +76,7 @@
                 </StackPanel>
             </GroupBox>
             <controls:TaskList VerticalAlignment="Top"
+                               Host="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}"
                                Tasks="{Binding Tasks}"></controls:TaskList>
         </DockPanel>
     </ContentControl>

--- a/RetroBar/Utilities/DictionaryManager.cs
+++ b/RetroBar/Utilities/DictionaryManager.cs
@@ -103,18 +103,28 @@ namespace RetroBar.Utilities
             }
             else
             {
+                // Built-in dictionary
                 dictFilePath = Path.ChangeExtension(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, dictFolder, dictionary),
                                                     dictExtension);
 
                 if (!File.Exists(dictFilePath))
                 {
-                    dictFilePath = // Custom dictionary in app directory
-                        Path.ChangeExtension(Path.Combine(Path.GetDirectoryName(ExePath.GetExecutablePath()), dictFolder, dictionary),
+                    // Installed dictionary in AppData directory
+                    dictFilePath = 
+                        Path.ChangeExtension(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "RetroBar", dictFolder, dictionary),
                                              dictExtension);
 
                     if (!File.Exists(dictFilePath))
                     {
-                        return;
+                        // Custom dictionary in app directory
+                        dictFilePath =
+                            Path.ChangeExtension(Path.Combine(Path.GetDirectoryName(ExePath.GetExecutablePath()), dictFolder, dictionary),
+                                                 dictExtension);
+
+                        if (!File.Exists(dictFilePath))
+                        {
+                            return;
+                        }
                     }
                 }
             }
@@ -141,12 +151,26 @@ namespace RetroBar.Utilities
         {
             List<string> dictionaries = new List<string> { dictDefault };
 
+            // Built-in dictionaries
             foreach (string subStr in Directory.GetFiles(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, dictFolder))
                                                .Where(s => Path.GetExtension(s).Contains(dictExtension)))
             {
                 dictionaries.Add(Path.GetFileNameWithoutExtension(subStr));
             }
 
+            // Installed AppData dictionaries
+            string installedDictDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "RetroBar", dictFolder);
+
+            if (Directory.Exists(installedDictDir))
+            {
+                foreach (string subStr in Directory.GetFiles(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "RetroBar", dictFolder))
+                                                   .Where(s => Path.GetExtension(s).Contains(dictExtension)))
+                {
+                    dictionaries.Add(Path.GetFileNameWithoutExtension(subStr));
+                }
+            }
+
+            // Same-folder dictionaries
             // Because RetroBar is published as a single-file app, it gets extracted to a temp directory, so custom dictionaries won't be there.
             // Get the executable path to find the custom dictionaries directory when not a debug build.
             string customDictDir = Path.Combine(Path.GetDirectoryName(ExePath.GetExecutablePath()), dictFolder);

--- a/RetroBar/Utilities/Settings.cs
+++ b/RetroBar/Utilities/Settings.cs
@@ -302,6 +302,26 @@ namespace RetroBar.Utilities
                 }
             }
         }
+
+        public int MultiMonMode
+        {
+            get
+            {
+                if (settings.MultiMonMode >= 0 && settings.MultiMonMode <= 2)
+                {
+                    return settings.MultiMonMode;
+                }
+
+                return 0;
+            }
+            set
+            {
+                if (settings.MultiMonMode != value && value >= 0 && value <= 2)
+                {
+                    settings.MultiMonMode = value;
+                }
+            }
+        }
         #endregion
 
         #region Helpers


### PR DESCRIPTION
- Added options to show tasks on: (#439)
  - All taskbars
  - Same taskbar as window
  - Same taskbar as window and primary taskbar
- Moved "RetroBar" settings section to its own tab and added version information (#184)
- Snuck in a change to allow installing themes to `%localappdata%\RetroBar\Themes`