### PR TITLE
Add show_windows_previews localization for Croatian

### DIFF
--- a/RetroBar/Languages/hrvatski.xaml
+++ b/RetroBar/Languages/hrvatski.xaml
@@ -27,6 +27,7 @@
     <s:String x:Key="show_quick_launch">Prika_ži brzo pokretanje</s:String>
     <s:String x:Key="select_location">_Select location...</s:String>
     <s:String x:Key="quick_launch_folder">Odaberi datoteku za brzo pokretanje</s:String>
+    <s:String x:Key="show_window_previews">Prikaži prikaz prozora(Umanjena sličica)</s:String>
     <s:String x:Key="use_software_rendering">_Koristi software prikazivanje</s:String>
     <s:String x:Key="ok_dialog">OK</s:String>
 


### PR DESCRIPTION
Just a pull request to add a missing line in the file for the Croatian language.