### PR TITLE
Add TaskListWrapPanel resource

### DIFF
--- a/RetroBar/Controls/TaskList.xaml
+++ b/RetroBar/Controls/TaskList.xaml
@@ -25,7 +25,7 @@
                       dd:DragDrop.DragDropContext="TaskList">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>
-                    <WrapPanel>
+                    <WrapPanel Style="{DynamicResource TaskListWrapPanel}">
                         <WrapPanel.Orientation>
                             <Binding Converter="{StaticResource orientationConverter}"
                                      Path="Orientation"

--- a/RetroBar/Themes/System.xaml
+++ b/RetroBar/Themes/System.xaml
@@ -503,6 +503,10 @@
         </Style.Triggers>
     </Style>
 
+    <Style x:Key="TaskListWrapPanel"
+           TargetType="WrapPanel">
+    </Style>
+
     <Style x:Key="ClassicFocusVisual">
         <Setter Property="Control.Template">
             <Setter.Value>


### PR DESCRIPTION
Allows centering taskbar items (#526)

For example:
```xaml
<Style x:Key="TaskListWrapPanel"
       TargetType="WrapPanel">
       <Setter Property="HorizontalAlignment"
               Value="Center" />
</Style>
```