### PR TITLE
fix: add a fallback to a new screen cache name

### DIFF
--- a/RetroBar/Utilities/WindowManager.cs
+++ b/RetroBar/Utilities/WindowManager.cs
@@ -162,7 +162,10 @@ namespace RetroBar.Utilities
         private void resetScreenCache()
         {
             // use reflection to empty screens cache
-            typeof(Screen).GetField("screens", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic).SetValue(null, null);
+            const System.Reflection.BindingFlags flags = System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic;
+            var fi = typeof(Screen).GetField("screens", flags) ?? typeof(Screen).GetField("s_screens", flags)
+                ?? throw new Exception("Can't find & reset screens cache inside winforms");
+            fi.SetValue(null, null);
         }
 
         public void Dispose()


### PR DESCRIPTION
new winforms changed a screen cache name [here](https://github.com/dotnet/winforms/pull/6630)

https://github.com/dotnet/winforms/blob/626e9fd067cb756d64bcda130922eab36dd960b2/src/System.Windows.Forms/src/System/Windows/Forms/Screen.cs#L52
