### PR TITLE
Fix missing tasks after screen change

### DIFF
--- a/RetroBar/Controls/TaskList.xaml.cs
+++ b/RetroBar/Controls/TaskList.xaml.cs
@@ -124,6 +124,11 @@ namespace RetroBar.Controls
                     return true;
                 }
 
+                if (Host.Screen.Primary && !Host.windowManager.IsValidHMonitor(window.HMonitor))
+                {
+                    return true;
+                }
+
                 if (window.HMonitor != Host.Screen.HMonitor)
                 {
                     return false;

--- a/RetroBar/Taskbar.xaml.cs
+++ b/RetroBar/Taskbar.xaml.cs
@@ -36,14 +36,15 @@ namespace RetroBar
         private Point? _mouseDragStart = null;
         private ShellManager _shellManager;
         private Updater _updater;
-        private WindowManager _windowManager;
+
+        public WindowManager windowManager;
 
         public Taskbar(WindowManager windowManager, ShellManager shellManager, StartMenuMonitor startMenuMonitor, Updater updater, AppBarScreen screen, AppBarEdge edge, AppBarMode mode)
             : base(shellManager.AppBarManager, shellManager.ExplorerHelper, shellManager.FullScreenHelper, screen, edge, mode, 0)
         {
             _shellManager = shellManager;
             _updater = updater;
-            _windowManager = windowManager;
+            this.windowManager = windowManager;
 
             InitializeComponent();
             DataContext = _shellManager;
@@ -170,7 +171,7 @@ namespace RetroBar
                 if (AllowsTransparency != newTransparency && Screen.Primary)
                 {
                     // Transparency cannot be changed on an open window.
-                    _windowManager.ReopenTaskbars();
+                    windowManager.ReopenTaskbars();
                     return;
                 }
 
@@ -202,7 +203,7 @@ namespace RetroBar
                 if (FlowDirection != newFlowDirection && Screen.Primary)
                 {
                     // It is necessary to reopen the taskbars to refresh menu sizes.
-                    _windowManager.ReopenTaskbars();
+                    windowManager.ReopenTaskbars();
                     return;
                 }
             }
@@ -234,7 +235,7 @@ namespace RetroBar
                 {
                     // Auto hide requires transparency
                     // Transparency cannot be changed on an open window.
-                    _windowManager.ReopenTaskbars();
+                    windowManager.ReopenTaskbars();
                 }
             }
             else if (e.PropertyName == "LockTaskbar")
@@ -361,7 +362,7 @@ namespace RetroBar
             if (Settings.Instance.ShowMultiMon)
             {
                 // Re-create RetroBar windows based on new screen setup
-                _windowManager.NotifyDisplayChange(reason);
+                windowManager.NotifyDisplayChange(reason);
             }
             else
             {

--- a/RetroBar/Utilities/WindowManager.cs
+++ b/RetroBar/Utilities/WindowManager.cs
@@ -90,6 +90,19 @@ namespace RetroBar.Utilities
             ShellLogger.Debug($"WindowManager: Finished processing display events");
         }
 
+        public bool IsValidHMonitor(IntPtr hMonitor)
+        {
+            foreach(var screen in _screenState)
+            {
+                if (screen.HMonitor == hMonitor)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private void closeTaskbars()
         {
             ShellLogger.Debug($"WindowManager: Closing all taskbars");

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.13",
+  "version": "1.14",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
When tasks are configured to display only on the same monitor as the window, screen changes can cause tasks to go missing due to having an invalid associated `hMonitor`. Show these on the primary screen so they aren't lost.

Fixes #499 