### PR TITLE
Fix tooltip after closing window, update ManagedShell

### DIFF
--- a/RetroBar/RetroBar.csproj
+++ b/RetroBar/RetroBar.csproj
@@ -45,7 +45,7 @@
 
   <ItemGroup>
     <PackageReference Include="gong-wpf-dragdrop" Version="3.1.1" />
-    <PackageReference Include="ManagedShell" Version="0.0.225" />
+    <PackageReference Include="ManagedShell" Version="0.0.231" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
   </ItemGroup>
 

--- a/RetroBar/Taskbar.xaml
+++ b/RetroBar/Taskbar.xaml
@@ -10,6 +10,7 @@
         LocationChanged="Taskbar_OnLocationChanged"
         SizeChanged="Taskbar_OnSizeChanged"
         MouseLeftButtonDown="Taskbar_OnMouseLeftButtonDown"
+        Deactivated="Taskbar_Deactivated"
         AllowDrop="True"
         Style="{DynamicResource TaskbarWindow}">
     <Window.Resources>

--- a/RetroBar/Taskbar.xaml.cs
+++ b/RetroBar/Taskbar.xaml.cs
@@ -290,6 +290,12 @@ namespace RetroBar
             StartButton?.UpdateFloatingStartCoordinates();
         }
 
+        private void Taskbar_Deactivated(object sender, EventArgs e)
+        {
+            // Prevent focus indicators and tooltips while not the active window
+            ResetControlFocus();
+        }
+
         private void DateTimeMenuItem_OnClick(object sender, RoutedEventArgs e)
         {
             ShellHelper.StartProcess("timedate.cpl");
@@ -334,6 +340,11 @@ namespace RetroBar
             }
         }
 
+        private void ResetControlFocus()
+        {
+            FocusDummyButton.MoveFocus(new TraversalRequest(FocusNavigationDirection.Left));
+        }
+
         protected override bool ShouldAllowAutoHide()
         {
             return (!_startMenuOpen || !Screen.Primary) && base.ShouldAllowAutoHide();
@@ -376,7 +387,7 @@ namespace RetroBar
             base.OnAutoHideAnimationBegin(isHiding);
 
             // Prevent focus indicators and tooltips while hidden
-            FocusDummyButton.MoveFocus(new TraversalRequest(FocusNavigationDirection.Left));
+            ResetControlFocus();
         }
 
         private void ContextMenu_Opened(object sender, RoutedEventArgs e)

--- a/RetroBar/Taskbar.xaml.cs
+++ b/RetroBar/Taskbar.xaml.cs
@@ -292,8 +292,12 @@ namespace RetroBar
 
         private void Taskbar_Deactivated(object sender, EventArgs e)
         {
-            // Prevent focus indicators and tooltips while not the active window
-            ResetControlFocus();
+            if (AppBarMode != AppBarMode.AutoHide)
+            {
+                // Prevent focus indicators and tooltips while not the active window
+                // When auto-hide is enabled, this is performed by auto-hide events instead
+                ResetControlFocus();
+            }
         }
 
         private void DateTimeMenuItem_OnClick(object sender, RoutedEventArgs e)


### PR DESCRIPTION
When the window is deactivated, focus the dummy control using the same method used with auto-hide enabled. This avoids a tooltip being displayed in undesirable scenarios (#364, #455).

The ManagedShell update contains the fix for #703.