### PR TITLE
Fix non-integer scales

### DIFF
--- a/RetroBar/Taskbar.xaml.cs
+++ b/RetroBar/Taskbar.xaml.cs
@@ -89,7 +89,6 @@ namespace RetroBar
         {
             base.OnSourceInitialized(sender, e);
 
-            SetLayoutRounding();
             SetBlur(Application.Current.FindResource("AllowsTransparency") as bool? ?? false);
             UpdateTrayPosition();
         }
@@ -109,19 +108,6 @@ namespace RetroBar
             }
 
             return IntPtr.Zero;
-        }
-
-        private void SetLayoutRounding()
-        {
-            // Layout rounding causes incorrect sizing on non-integer scales
-            if (DpiScale % 1 != 0)
-            {
-                UseLayoutRounding = false;
-            }
-            else
-            {
-                UseLayoutRounding = true;
-            }
         }
 
         private void UpdateTrayPosition()
@@ -370,7 +356,6 @@ namespace RetroBar
             {
                 // DPI change is per-monitor, update ourselves
                 SetScreenPosition();
-                SetLayoutRounding();
                 return;
             }
 

--- a/RetroBar/Themes/System.xaml
+++ b/RetroBar/Themes/System.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
 
-    <system:Double x:Key="TaskbarHeight">28</system:Double>
+    <system:Double x:Key="TaskbarHeight">30</system:Double>
     <system:Double x:Key="TaskbarWidth">98</system:Double>
     <system:Double x:Key="TaskbarUnlockedSize">0</system:Double>
     <system:Double x:Key="TaskButtonWidth">160</system:Double>

--- a/RetroBar/Themes/Windows Longhorn Aero.xaml
+++ b/RetroBar/Themes/Windows Longhorn Aero.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
 
-    <system:Double x:Key="TaskbarHeight">30</system:Double>
+    <system:Double x:Key="TaskbarHeight">32</system:Double>
     <system:Boolean x:Key="AllowsTransparency">True</system:Boolean>
     <Thickness x:Key="TaskButtonMargin" Right="2" />
 

--- a/RetroBar/Themes/Windows Vista Aero.xaml
+++ b/RetroBar/Themes/Windows Vista Aero.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
 
-    <system:Double x:Key="TaskbarHeight">30</system:Double>
+    <system:Double x:Key="TaskbarHeight">34</system:Double>
     <system:Double x:Key="TaskbarWidth">80</system:Double>
     <system:Boolean x:Key="AllowsTransparency">True</system:Boolean>
     <system:Boolean x:Key="UseFloatingStartButton">True</system:Boolean>

--- a/RetroBar/Themes/Windows XP Blue.xaml
+++ b/RetroBar/Themes/Windows XP Blue.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
 
-    <system:Double x:Key="TaskbarHeight">30</system:Double>
+    <system:Double x:Key="TaskbarHeight">32</system:Double>
     <system:Double x:Key="TaskbarUnlockedSize">4</system:Double>
     <Thickness x:Key="TaskButtonMargin" />
 


### PR DESCRIPTION
Fix incorrect sizing on non-integer scales https://github.com/dremin/RetroBar/issues/727

Due to the lack of TaskbarHeight, scaling by automatic calculation does not seem to be possible.

175% scale (Image 8x)

![175_8x](https://github.com/dremin/RetroBar/assets/20138367/8b3b9dc7-98a7-4753-902e-c459534a5988)


