### PR TITLE
Add theme-independent clock format customization

### DIFF
--- a/RetroBar/Controls/Clock.xaml.cs
+++ b/RetroBar/Controls/Clock.xaml.cs
@@ -78,16 +78,26 @@ namespace RetroBar.Controls
 
         private void Settings_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == "ShowClock")
-            {
-                if (Settings.Instance.ShowClock)
-                {
-                    StartClock();
-                }
-                else
-                {
-                    StopClock();
-                }
+            switch (e.PropertyName) {
+                case "ShowClock":
+                    if (Settings.Instance.ShowClock)
+                    {
+                        StartClock();
+                    }
+                    else
+                    {
+                        StopClock();
+                    }
+                    break;
+
+                case "Theme":
+                case "OverrideClockFormat":
+                case "ClockFormat":
+                case "OverrideAMPMDesignators":
+                case "AMDesignator":
+                case "PMDesignator":
+                    SetCurrentCulture();
+                    break;
             }
         }
 
@@ -155,6 +165,24 @@ namespace RetroBar.Controls
                 iCi.DateTimeFormat.TimeSeparator = (string)iKey.GetValue("sTime");
                 iCi.DateTimeFormat.AMDesignator = (string)iKey.GetValue("s1159");
                 iCi.DateTimeFormat.PMDesignator = (string)iKey.GetValue("s2359");
+
+                // Override culture info if desired, inserting newlines where appropriate
+                if (Settings.Instance.OverrideClockFormat && Settings.Instance.ClockFormat != "")
+                {
+                    iCi.DateTimeFormat.ShortTimePattern = Settings.Instance.ClockFormat.Replace("\\n", "\n");
+                }
+
+                if (Settings.Instance.OverrideAMPMDesignators)
+                {
+                    if (Settings.Instance.AMDesignator != "")
+                    {
+                        iCi.DateTimeFormat.AMDesignator = Settings.Instance.AMDesignator;
+                    }
+                    if (Settings.Instance.PMDesignator != "")
+                    {
+                        iCi.DateTimeFormat.PMDesignator = Settings.Instance.PMDesignator;
+                    }
+                }
 
                 CultureInfo.CurrentCulture = iCi;
                 SetConverterCultureRecursively(this);

--- a/RetroBar/Languages/English.xaml
+++ b/RetroBar/Languages/English.xaml
@@ -4,6 +4,7 @@
 
     <s:String x:Key="retrobar_properties">RetroBar Properties</s:String>
     <s:String x:Key="taskbar_tab">Taskbar</s:String>
+    <s:String x:Key="clock_tab">Clock</s:String>
     <s:String x:Key="advanced_tab">Advanced</s:String>
     <s:String x:Key="taskbar_appearance">Taskbar appearance</s:String>
     <s:String x:Key="notification_area">Notification area</s:String>
@@ -56,6 +57,14 @@
     <s:String x:Key="taskbar_scale_current">Current setting: {0}%</s:String>
     <s:String x:Key="debug_logging">Enable debug logging</s:String>
     <s:String x:Key="ok_dialog">OK</s:String>
+
+    <s:String x:Key="clock_appearance">Clock appearance</s:String>
+    <s:String x:Key="clock_format_info" xml:space="preserve">What the notations mean:&#10;&#10;h = hour; m = minute, s = second, tt = AM/PM&#10;d = day; M = month; yy, yyyy = year&#10;ddd, dddd = weekday; MMM, MMMM = month name&#10;&#10;h/H = 12/24 hour&#10;hh, mm, ss, dd, MM = display leading zero&#10;h, m, s, d, M = do not display leading zero&#10;&#10;\n = split clock into multiple lines&#10;(not recommended on all themes)&#10;&#10;Use "\" in front of other notations to use their actual characters</s:String>
+    <s:String x:Key="clock_format_warning" xml:space="preserve">Note: Custom clock formatting may not be applied&#10;if your selected theme specifies its own format.</s:String>
+    <s:String x:Key="override_clock_format">Custom clock _format:</s:String>
+    <s:String x:Key="override_ampm_designators">Custom _designators:</s:String>
+    <s:String x:Key="am_designator">AM:</s:String>
+    <s:String x:Key="pm_designator">PM:</s:String>
 
     <s:String x:Key="customize_notifications">Customize Notifications</s:String>
     <s:String x:Key="customize_notifications_info">RetroBar displays icons for active and urgent notifications, and hides inactive ones. You can change this behavior for items in the list below.</s:String>

--- a/RetroBar/PropertiesWindow.xaml
+++ b/RetroBar/PropertiesWindow.xaml
@@ -87,6 +87,50 @@
                 <Setter Property="Width"
                         Value="335" />
             </Style>
+            <ControlTemplate x:Key="NotificationAreaPreview">
+                <Border Style="{StaticResource PreviewBorder}">
+                    <ContentControl Height="{DynamicResource TaskbarHeight}"
+                                    IsHitTestVisible="False"
+                                    Focusable="False"
+                                    ClipToBounds="True"
+                                    Style="{DynamicResource Taskbar}">
+                        <TextOptions.TextRenderingMode>
+                            <Binding Source="{x:Static Settings:Settings.Instance}"
+                                     Path="AllowFontSmoothing"
+                                     Converter="{StaticResource textRenderingModeConverter}" />
+                        </TextOptions.TextRenderingMode>
+                        <DockPanel>
+                            <controls:ShowDesktopButton DockPanel.Dock="Right" HorizontalAlignment="Center" Visibility="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowDesktopButton, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource boolToVisibilityConverter}}" />
+                            <GroupBox Style="{DynamicResource Tray}"
+                                        DockPanel.Dock="Right">
+                                <StackPanel Orientation="Horizontal">
+                                    <StackPanel Orientation="Horizontal">
+                                        <ToggleButton x:Name="NotifyIconToggleButton"
+                                                      Focusable="False"
+                                                      Visibility="{Binding CollapseNotifyIcons, Converter={StaticResource boolToVisibilityConverter}, Source={x:Static Settings:Settings.Instance}, UpdateSourceTrigger=PropertyChanged}"
+                                                      Style="{DynamicResource TrayToggleButton}"/>
+                                        <ItemsControl Focusable="False"
+                                                      HorizontalAlignment="Center"
+                                                      VerticalAlignment="Center">
+                                            <ItemsControl.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <WrapPanel Orientation="Horizontal"/>
+                                                </ItemsPanelTemplate>
+                                            </ItemsControl.ItemsPanel>
+                                            <Border>
+                                                <Image Source="Resources\retrobar.ico"
+                                                       Style="{DynamicResource NotifyIcon}" />
+                                            </Border>
+                                        </ItemsControl>
+                                    </StackPanel>
+                                    <controls:Clock VerticalAlignment="Center" />
+                                </StackPanel>
+                            </GroupBox>
+                            <StackPanel/>
+                        </DockPanel>
+                    </ContentControl>
+                </Border>
+            </ControlTemplate>
         </ResourceDictionary>
     </Window.Resources>
     <Grid Margin="7">
@@ -229,53 +273,8 @@
                     </GroupBox>
                     <GroupBox Header="{DynamicResource notification_area}">
                         <StackPanel Orientation="Vertical">
-                            <Border Style="{StaticResource PreviewBorder}">
-                                <ContentControl Height="{DynamicResource TaskbarHeight}"
-                                                IsHitTestVisible="False"
-                                                Focusable="False"
-                                                ClipToBounds="True"
-                                                Style="{DynamicResource Taskbar}">
-                                    <TextOptions.TextRenderingMode>
-                                        <Binding Source="{x:Static Settings:Settings.Instance}"
-                                                 Path="AllowFontSmoothing"
-                                                 Converter="{StaticResource textRenderingModeConverter}" />
-                                    </TextOptions.TextRenderingMode>
-                                    <DockPanel>
-                                        <controls:ShowDesktopButton DockPanel.Dock="Right" HorizontalAlignment="Center" Visibility="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowDesktopButton, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource boolToVisibilityConverter}}" />
-                                        <GroupBox Style="{DynamicResource Tray}"
-                                                  DockPanel.Dock="Right">
-                                            <StackPanel Orientation="Horizontal">
-                                                <StackPanel Orientation="Horizontal">
-                                                    <ToggleButton Name="NotifyIconToggleButton"
-                                                                  Focusable="False"
-                                                                  Visibility="{Binding Source={x:Static Settings:Settings.Instance}, Path=CollapseNotifyIcons, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource boolToVisibilityConverter}}"
-                                                                  Style="{DynamicResource TrayToggleButton}"/>
-                                                    <ItemsControl Focusable="False"
-                                                                  HorizontalAlignment="Center"
-                                                                  VerticalAlignment="Center">
-                                                        <ItemsControl.ItemsPanel>
-                                                            <ItemsPanelTemplate>
-                                                                <WrapPanel Orientation="Horizontal"></WrapPanel>
-                                                            </ItemsPanelTemplate>
-                                                        </ItemsControl.ItemsPanel>
-                                                        <Border>
-                                                            <Image Source="Resources\retrobar.ico"
-                                                                   Style="{DynamicResource NotifyIcon}" />
-                                                        </Border>
-                                                    </ItemsControl>
-                                                </StackPanel>
-                                                <controls:Clock VerticalAlignment="Center" />
-                                            </StackPanel>
-                                        </GroupBox>
-                                        <StackPanel></StackPanel>
-                                        <controls:KeyboardLayout VerticalAlignment="Center" HorizontalAlignment="Right"/>
-                                    </DockPanel>
-                                </ContentControl>
-                            </Border>
-                            <CheckBox x:Name="cbShowKeyboardLayout"
-                                      IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowKeyboardLayout, UpdateSourceTrigger=PropertyChanged}">
-                                <Label Content="{DynamicResource show_keyboard_layout}" />
-                            </CheckBox>
+                            <ContentControl Template="{StaticResource NotificationAreaPreview}"
+                                            Focusable="False" />
                             <CheckBox x:Name="cbShowClock"
                                       IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowClock, UpdateSourceTrigger=PropertyChanged}">
                                 <Label Content="{DynamicResource show_clock}" />
@@ -296,6 +295,72 @@
                             </DockPanel>
                         </StackPanel>
                     </GroupBox>
+                </StackPanel>
+            </TabItem>
+            <TabItem Header="{DynamicResource clock_tab}" >
+                <StackPanel Orientation="Vertical"
+                            Margin="10">
+                    <DockPanel>
+                        <GroupBox Header="{DynamicResource clock_appearance}"
+                                  Margin="0,0,0,10">
+                            <StackPanel Orientation="Vertical">
+                                <ContentControl Template="{StaticResource NotificationAreaPreview}"
+                                                Focusable="False" />
+                                <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowClock, UpdateSourceTrigger=PropertyChanged}">
+                                    <Label Content="{DynamicResource show_clock}" />
+                                </CheckBox>
+                                <DockPanel DockPanel.Dock="Top">
+                                    <CheckBox x:Name="cbOverrideClockFormat"
+                                              VerticalAlignment="Center"
+                                              IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=OverrideClockFormat, UpdateSourceTrigger=PropertyChanged}">
+                                        <Label Content="{DynamicResource override_clock_format}" />
+                                    </CheckBox>
+                                    <TextBox Text="{Binding Source={x:Static Settings:Settings.Instance}, Path=ClockFormat, UpdateSourceTrigger=PropertyChanged}"
+                                             TextWrapping="Wrap"
+                                             VerticalAlignment="Center"
+                                             Margin="5,0,0,0"
+                                             IsEnabled="{Binding Source={x:Static Settings:Settings.Instance}, Path=OverrideClockFormat, UpdateSourceTrigger=PropertyChanged}" />
+                                </DockPanel>
+                                <DockPanel VerticalAlignment="Top" >
+                                    <CheckBox x:Name="cbOverrideAMPMDesignators"
+                                              VerticalAlignment="Center"
+                                              IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=OverrideAMPMDesignators, UpdateSourceTrigger=PropertyChanged}">
+                                        <Label Content="{DynamicResource override_ampm_designators}" />
+                                    </CheckBox>
+                                    <UniformGrid Columns="2">
+                                        <DockPanel>
+                                            <Label Content="{DynamicResource am_designator}"
+                                                   VerticalAlignment="Center"
+                                                   Margin="10,0,0,2"
+                                                   IsEnabled="{Binding Source={x:Static Settings:Settings.Instance}, Path=OverrideAMPMDesignators, UpdateSourceTrigger=PropertyChanged}" />
+                                            <TextBox Text="{Binding Source={x:Static Settings:Settings.Instance}, Path=AMDesignator, UpdateSourceTrigger=PropertyChanged}"
+                                                     TextWrapping="Wrap"
+                                                     VerticalAlignment="Center"
+                                                     Margin="5,0,0,0"
+                                                     IsEnabled="{Binding Source={x:Static Settings:Settings.Instance}, Path=OverrideAMPMDesignators, UpdateSourceTrigger=PropertyChanged}" />
+                                        </DockPanel>
+                                        <DockPanel>
+                                            <Label Content="{DynamicResource pm_designator}"
+                                                   Margin="10,0,0,2"
+                                                   VerticalAlignment="Center"
+                                                   IsEnabled="{Binding Source={x:Static Settings:Settings.Instance}, Path=OverrideAMPMDesignators, UpdateSourceTrigger=PropertyChanged}" />
+                                            <TextBox Text="{Binding Source={x:Static Settings:Settings.Instance}, Path=PMDesignator, UpdateSourceTrigger=PropertyChanged}"
+                                                     TextWrapping="Wrap"
+                                                     VerticalAlignment="Center"
+                                                     Margin="5,0,0,0"
+                                                     IsEnabled="{Binding Source={x:Static Settings:Settings.Instance}, Path=OverrideAMPMDesignators, UpdateSourceTrigger=PropertyChanged}" />
+                                        </DockPanel>
+                                    </UniformGrid>
+                                </DockPanel>
+                                <TextBlock Text="{DynamicResource clock_format_warning}"
+                                           TextWrapping="Wrap"
+                                           TextAlignment="Center"
+                                           Margin="0,3,0,3" />
+                            </StackPanel>
+                        </GroupBox>
+                    </DockPanel>
+                    <TextBlock Text="{DynamicResource clock_format_info}"
+                               TextWrapping="Wrap" />
                 </StackPanel>
             </TabItem>
             <TabItem Header="{DynamicResource advanced_tab}">

--- a/RetroBar/Utilities/Settings.cs
+++ b/RetroBar/Utilities/Settings.cs
@@ -121,6 +121,91 @@ namespace RetroBar.Utilities
             }
         }
 
+        private bool _overrideClockFormat = false;
+        public bool OverrideClockFormat
+        {
+            get
+            {
+                return _overrideClockFormat;
+            }
+            set
+            {
+                if (_overrideClockFormat != value)
+                {
+                    _overrideClockFormat = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private string _clockFormat = "h:mm:ss tt | ddd, MMM d, yyyy";
+        public string ClockFormat
+        {
+            get
+            {
+                return _clockFormat;
+            }
+            set
+            {
+                if (_clockFormat != value)
+                {
+                    _clockFormat = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private bool _overrideAMPMDesignators = false;
+        public bool OverrideAMPMDesignators
+        {
+            get
+            {
+                return _overrideAMPMDesignators;
+            }
+            set
+            {
+                if (_overrideAMPMDesignators != value)
+                {
+                    _overrideAMPMDesignators = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private string _amDesignator = "a.m.";
+        public string AMDesignator
+        {
+            get
+            {
+                return _amDesignator;
+            }
+            set
+            {
+                if (_amDesignator != value)
+                {
+                    _amDesignator = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private string _pmDesignator = "p.m.";
+        public string PMDesignator
+        {
+            get
+            {
+                return _pmDesignator;
+            }
+            set
+            {
+                if (_pmDesignator != value)
+                {
+                    _pmDesignator = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
         private bool _showDesktopButton = false;
         public bool ShowDesktopButton
         {


### PR DESCRIPTION
https://github.com/dremin/RetroBar/assets/48284263/148dde8a-b47c-4123-8d37-24df7fd8bd72

Fixes #217, #300, #477, #671, #726
Partially fixes #110, #445, #508


### Changes
- Adds a new `Clock` tab to the settings dialog:
	- Set custom clock formatting
		- Split clock into multiple lines using `\n`
	- Set custom AM/PM designators

This works by simply overriding `CultureInfo.DateTimeFormat`'s `ShortTimePattern`, `AMDesignator`, and `PMDesignator` properties in `Clock.SetCurrentCulture()` with our custom values. Editing any of the formatting settings (or changing the theme, to fix an unusual bug) resets the culture, so your changes are reflected in real time.

Also, I turned the "Notification area" preview into a `ControlTemplate` and moved it into the resource dictionary (using the key `"NotificationAreaPreview"`) so I could reuse it. I don't know if this is how you're supposed to do it.


### Minor issues

<details>

- I didn't bother adding support for escaping `\n` so the literal sequence "\n" cannot appear on the clock (unless you put it in the designators). I apologize for the thousands of issues that will surely be opened regarding this.
- Leaving the format/designators blank will have them fallback to their normal values, to prevent confusion. Having only whitespace as your format/designator is still accepted however, which itself might cause confusion, but it can be used as makeshift padding so I left it as is.
- Ending the clock format with a single backlash causes the entire clock to become blank. Fixing this "properly" means counting the number of trailing backslashes to see if there's an odd or even number so you know whether or not to remove the last one, so I just... didn't.

</details>


### Irrelevant notes

<details>

- I prototyped a setting for optionally overriding even a themed clock's baked-in format, but I ultimately decided against it.
- I chose `h:mm:ss tt | ddd, MMM d, yyyy` and `a.m.`/`p.m.` as the default format and designators to make it clear to the user how far they can take the formatting before they actually read the text at the bottom. I didn't include `\n` however, as multi-line clocks don't look good on themes with harsh gradients or limited clock space (like the default theme).
- The "What the notations mean" text is derived from the [official Windows dialogs.](https://i.imgur.com/yAvWpV6.png)
	- I defined all of that text as a _single line_. Sorry for making `Languages/English.xaml` really, really wide.
- The `Show the clock` checkbox logically fits on both tabs, but I didn't want to disturb the nostalgic sanctity of its original placement, so I duplicated it. Let me know if that's okay.
- I spent an excessive amount of time deciding on aesthetics/presentation, and I only settled on adding a new tab for [clarity](https://i.imgur.com/ikEcpgf.png) and [aesthetics](https://i.imgur.com/AvZmzP4.png). I hope what I ended up with is acceptable. I think if any additional clock settings are added, the layout should probably be rearranged - I went for [something like this](https://i.imgur.com/QswIfug.png) at first but it felt too claustrophobic with the limited number of settings (just look at that groupbox-less preview clock, it's basically naked).
- XAML is the worst thing that's ever happened to anyone ever

</details>