### PR TITLE
Handle error getting keyboard layout

### DIFF
--- a/RetroBar/Controls/InputLanguage.xaml.cs
+++ b/RetroBar/Controls/InputLanguage.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Threading;
 using ManagedShell.Common.Helpers;
+using ManagedShell.Common.Logging;
 using RetroBar.Utilities;
 
 namespace RetroBar.Controls
@@ -47,8 +48,15 @@ namespace RetroBar.Controls
 
         private void SetLocaleIdentifier()
         {
-            var managedShellLayout = KeyboardLayoutHelper.GetKeyboardLayout(false);
-            LocaleIdentifier = CultureInfo.GetCultureInfo((short)managedShellLayout.HKL);
+            try
+            {
+                var managedShellLayout = KeyboardLayoutHelper.GetKeyboardLayout(false);
+                LocaleIdentifier = CultureInfo.GetCultureInfo((short)managedShellLayout.HKL);
+            }
+            catch (Exception ex)
+            {
+                ShellLogger.Error($"Error getting locale identifier: {ex.Message}");
+            }
         }
 
         private void StartWatch()

--- a/RetroBar/Utilities/Settings.cs
+++ b/RetroBar/Utilities/Settings.cs
@@ -1,8 +1,6 @@
 ﻿using ManagedShell.AppBar;
-using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.IO;
 using System.Runtime.CompilerServices;
 
 namespace RetroBar.Utilities


### PR DESCRIPTION
Fixes #758.

Of course we should improve ManagedShell to fix the error, but RetroBar should handle an error here anyway.