### PR TITLE
Ability to configure which tray icons get inverted

### DIFF
--- a/RetroBar/Controls/NotifyIcon.xaml.cs
+++ b/RetroBar/Controls/NotifyIcon.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows.Input;
 using ManagedShell.Common.Helpers;
 using ManagedShell.Interop;
 using ManagedShell.WindowsTray;
+using RetroBar.Extensions;
 using RetroBar.Utilities;
 
 namespace RetroBar.Controls
@@ -33,21 +34,12 @@ namespace RetroBar.Controls
 
         private void applyEffects()
         {
-            if ((!EnvironmentHelper.IsWindows10OrBetter && Settings.Instance.InvertIconsMode == Settings.InvertIconsOption.WhenNeededByTheme) || TrayIcon == null || Settings.Instance.InvertIconsMode == Settings.InvertIconsOption.Never)
+            if (TrayIcon == null || Settings.Instance.InvertIconsMode == Settings.InvertIconsOption.Never)
             {
                 return;
             }
 
-            string iconGuid = TrayIcon.GUID.ToString();
-
-            if (!(iconGuid == NotificationArea.HARDWARE_GUID ||
-                iconGuid == NotificationArea.UPDATE_GUID ||
-                iconGuid == NotificationArea.MICROPHONE_GUID ||
-                iconGuid == NotificationArea.LOCATION_GUID ||
-                iconGuid == NotificationArea.MEETNOW_GUID ||
-                iconGuid == NotificationArea.NETWORK_GUID ||
-                iconGuid == NotificationArea.POWER_GUID ||
-                iconGuid == NotificationArea.VOLUME_GUID))
+            if (!TrayIcon.CanInvert())
             {
                 return;
             }

--- a/RetroBar/Controls/NotifyIconList.xaml.cs
+++ b/RetroBar/Controls/NotifyIconList.xaml.cs
@@ -51,12 +51,12 @@ namespace RetroBar.Controls
                     NotifyIcons.ItemsSource = allNotifyIconsSource.View;
                 }
             }
-            else if (e.PropertyName == "InvertIconsMode")
+            else if (e.PropertyName == "InvertIconsMode" || e.PropertyName == "InvertNotifyIcons")
             {
                 // Reload icons
                 NotifyIcons.ItemsSource = null;
 
-                if (Settings.Instance.CollapseNotifyIcons)
+                if (Settings.Instance.CollapseNotifyIcons && NotifyIconToggleButton.IsChecked != true)
                 {
                     NotifyIcons.ItemsSource = pinnedNotifyIconsSource.View;
                 }

--- a/RetroBar/Converters/BoolToIntConverter.cs
+++ b/RetroBar/Converters/BoolToIntConverter.cs
@@ -10,7 +10,12 @@ namespace RetroBar.Converters
         {
             if (value is bool boolValue)
             {
-                return boolValue ? 1 : 0;
+                var multiplier = 1;
+                if (parameter is string strValue)
+                {
+                    multiplier = System.Convert.ToInt32(strValue);
+                }
+                return boolValue ? 1 * multiplier : 0;
             }
 
             return Binding.DoNothing;

--- a/RetroBar/Converters/NotifyIconCanInvertConverter.cs
+++ b/RetroBar/Converters/NotifyIconCanInvertConverter.cs
@@ -1,0 +1,26 @@
+﻿using ManagedShell.WindowsTray;
+using RetroBar.Extensions;
+using System;
+using System.Windows.Data;
+
+namespace RetroBar.Converters
+{
+    [ValueConversion(typeof(NotifyIcon), typeof(bool))]
+    public class NotifyIconCanInvertConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value is NotifyIcon icon)
+            {
+                return icon.CanInvert();
+            }
+
+            return Binding.DoNothing;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return Binding.DoNothing;
+        }
+    }
+}

--- a/RetroBar/Extensions/NotifyIconExtensions.cs
+++ b/RetroBar/Extensions/NotifyIconExtensions.cs
@@ -1,0 +1,44 @@
+﻿using ManagedShell.WindowsTray;
+using RetroBar.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RetroBar.Extensions
+{
+    public static class NotifyIconExtensions
+    {
+
+        public static string GetInvertIdentifier(this NotifyIcon icon)
+        {
+            if (icon.GUID != default) return icon.GUID.ToString();
+            else return icon.Path + ":" + icon.UID.ToString();
+        }
+
+        public static bool CanInvert(this NotifyIcon icon) {
+            return Settings.Instance.InvertNotifyIcons.Contains(icon.GetInvertIdentifier());
+        }
+
+        public static void SetCanInvert(this NotifyIcon icon, bool canInvert)
+        {
+            var identifier = icon.GetInvertIdentifier();
+            var settings = new List<string>(Settings.Instance.InvertNotifyIcons);
+            var changed = false;
+
+            if (!canInvert)
+            {
+                changed = settings.Remove(identifier);
+            }
+            else if (!settings.Contains(identifier))
+            {
+                settings.Add(identifier);
+                changed = true;
+            }
+
+            if (changed)
+            {
+                Settings.Instance.InvertNotifyIcons = settings;
+            }
+        }
+    }
+}

--- a/RetroBar/Extensions/NotifyIconExtensions.cs
+++ b/RetroBar/Extensions/NotifyIconExtensions.cs
@@ -1,14 +1,11 @@
 ﻿using ManagedShell.WindowsTray;
 using RetroBar.Utilities;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace RetroBar.Extensions
 {
     public static class NotifyIconExtensions
     {
-
         public static string GetInvertIdentifier(this NotifyIcon icon)
         {
             if (icon.GUID != default) return icon.GUID.ToString();

--- a/RetroBar/Languages/English.xaml
+++ b/RetroBar/Languages/English.xaml
@@ -65,6 +65,7 @@
     <s:String x:Key="always_show">Always show</s:String>
     <s:String x:Key="name_heading">Name</s:String>
     <s:String x:Key="behavior_heading">Behavior</s:String>
+    <s:String x:Key="invert_heading">Invert</s:String>
 
     <s:String x:Key="start_text">Start</s:String>
     <s:String x:Key="start_text_xp">start</s:String>

--- a/RetroBar/NotificationPropertiesWindow.xaml
+++ b/RetroBar/NotificationPropertiesWindow.xaml
@@ -2,6 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:converters="clr-namespace:RetroBar.Converters"
+        xmlns:Settings="clr-namespace:RetroBar.Utilities"
         Title="{DynamicResource customize_notifications}"
         Height="406"
         Width="364"
@@ -12,7 +13,9 @@
     <Window.Resources>
         <ResourceDictionary>
             <converters:BoolToIntConverter x:Key="boolToIntConverter" />
+            <converters:BoolToVisibilityConverter x:Key="boolToVisibilityConverter" />
             <converters:NewLineToSpaceConverter x:Key="newLineToSpaceConverter" />
+            <converters:NotifyIconCanInvertConverter x:Key="notifyIconCanInvertConverter" />
             <Style TargetType="{x:Type ComboBox}">
                 <Setter Property="HorizontalAlignment"
                         Value="Right" />
@@ -54,11 +57,13 @@
         </Grid.RowDefinitions>
         <DockPanel Grid.Row="0">
             <TextBlock Text="{DynamicResource customize_notifications_info}"
+                       Visibility="{Binding Source={x:Static Settings:Settings.Instance}, Path=CollapseNotifyIcons, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource boolToVisibilityConverter}}"
                        TextWrapping="Wrap"
+                       Margin="0,0,0,20"
                        DockPanel.Dock="Top" />
             <TextBlock Text="{DynamicResource customize_notifications_instruction}"
                        TextWrapping="Wrap"
-                       Margin="0,20,0,3"
+                       Margin="0,0,0,3"
                        DockPanel.Dock="Top" />
             <ListView VerticalAlignment="Stretch"
                       ItemsSource="{Binding AllIcons}"
@@ -66,11 +71,12 @@
                 <ListView.View>
                     <GridView>
                         <GridViewColumn Header="{DynamicResource name_heading}"
-                                        Width="180">
+                                        Width="145">
                             <GridViewColumn.CellTemplate>
                                 <DataTemplate>
                                     <DockPanel>
                                         <Image Source="{Binding Icon}"
+                                               Loaded="Icon_Loaded"
                                                Width="16"
                                                Height="16"
                                                Margin="0,0,3,0"
@@ -85,7 +91,7 @@
                             </GridViewColumn.CellTemplate>
                         </GridViewColumn>
                         <GridViewColumn Header="{DynamicResource behavior_heading}"
-                                        Width="120">
+                                        Width="{Binding Source={x:Static Settings:Settings.Instance}, Path=CollapseNotifyIcons, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource boolToIntConverter}, ConverterParameter=120}">
                             <GridViewColumn.CellTemplate>
                                 <DataTemplate>
                                     <StackPanel>
@@ -125,6 +131,16 @@
                                             </DataTrigger.Setters>
                                         </DataTrigger>
                                     </DataTemplate.Triggers>
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+                        <GridViewColumn Header="{DynamicResource invert_heading}"
+                                        Width="Auto">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <CheckBox IsChecked="{Binding Mode=OneWay, Converter={StaticResource notifyIconCanInvertConverter}}"
+                                              Checked="InvertCheckBox_Checked"
+                                              Unchecked="InvertCheckBox_Unchecked" />
                                 </DataTemplate>
                             </GridViewColumn.CellTemplate>
                         </GridViewColumn>

--- a/RetroBar/NotificationPropertiesWindow.xaml.cs
+++ b/RetroBar/NotificationPropertiesWindow.xaml.cs
@@ -1,6 +1,8 @@
 ﻿using ManagedShell.WindowsTray;
+using RetroBar.Extensions;
 using RetroBar.Utilities;
 using System.Windows;
+using System.Windows.Controls;
 
 namespace RetroBar
 {
@@ -20,6 +22,17 @@ namespace RetroBar
             InitializeComponent();
 
             DataContext = _notificationArea;
+            Settings.Instance.PropertyChanged += Settings_PropertyChanged;
+        }
+
+        private void Settings_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == "InvertNotifyIcons")
+            {
+                // Reload icons
+                DataContext = null;
+                DataContext = _notificationArea;
+            }
         }
 
         public static void Open(NotificationArea notificationArea, Point position)
@@ -44,12 +57,53 @@ namespace RetroBar
 
         private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
         {
+            Settings.Instance.PropertyChanged -= Settings_PropertyChanged;
             _instance = null;
         }
 
-        private void BehaviorComboBox_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        private void BehaviorComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             Settings.Instance.PinnedNotifyIcons = _notificationArea.PinnedNotifyIcons;
+        }
+
+        private void InvertCheckBox_Checked(object sender, RoutedEventArgs e)
+        {
+            var checkBox = sender as CheckBox;
+            var icon = checkBox.DataContext as NotifyIcon;
+            icon.SetCanInvert(true);
+        }
+
+        private void InvertCheckBox_Unchecked(object sender, RoutedEventArgs e)
+        {
+            var checkBox = sender as CheckBox;
+            var icon = checkBox.DataContext as NotifyIcon;
+            icon.SetCanInvert(false);
+        }
+
+        private void Icon_Loaded(object sender, RoutedEventArgs e)
+        {
+            var image = sender as Image;
+            var notifyIcon = image.DataContext as NotifyIcon;
+            applyEffects(image, notifyIcon);
+        }
+
+        private void applyEffects(Image NotifyIconImage, NotifyIcon TrayIcon)
+        {
+            if (TrayIcon == null)
+            {
+                return;
+            }
+
+            if (!TrayIcon.CanInvert())
+            {
+                NotifyIconImage.Effect = null;
+                return;
+            }
+
+            if (NotifyIconImage.Effect == null)
+            {
+                NotifyIconImage.Effect = new InvertEffect();
+            }
         }
     }
 }

--- a/RetroBar/PropertiesWindow.xaml
+++ b/RetroBar/PropertiesWindow.xaml
@@ -334,6 +334,9 @@
                                       SelectedIndex="{Binding Source={x:Static Settings:Settings.Instance}, Path=InvertIconsMode, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource enumConverter}}"
                                       SelectionChanged="cboInvertIconsMode_SelectionChanged" />
                         </DockPanel>
+                        <Button HorizontalAlignment="Right"
+                                        Content="{DynamicResource customize}"
+                                        Click="CustomizeNotifications_OnClick" />
                     </StackPanel>
                     <GroupBox Header="{DynamicResource multiple_displays}"
                               Margin="0,0,0,10">

--- a/RetroBar/RetroBar.csproj
+++ b/RetroBar/RetroBar.csproj
@@ -45,7 +45,7 @@
 
   <ItemGroup>
     <PackageReference Include="gong-wpf-dragdrop" Version="3.1.1" />
-    <PackageReference Include="ManagedShell" Version="0.0.240" />
+    <PackageReference Include="ManagedShell" Version="0.0.245" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
   </ItemGroup>
 

--- a/RetroBar/Utilities/Settings.cs
+++ b/RetroBar/Utilities/Settings.cs
@@ -1,4 +1,6 @@
 ﻿using ManagedShell.AppBar;
+using ManagedShell.Common.Helpers;
+using ManagedShell.WindowsTray;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
@@ -221,6 +223,23 @@ namespace RetroBar.Utilities
             }
         }
 
+        private List<string> _invertNotifyIcons = new List<string> { NotificationArea.HARDWARE_GUID, NotificationArea.UPDATE_GUID, NotificationArea.MICROPHONE_GUID, NotificationArea.LOCATION_GUID, NotificationArea.MEETNOW_GUID, NotificationArea.NETWORK_GUID, NotificationArea.POWER_GUID, NotificationArea.VOLUME_GUID };
+        public List<string> InvertNotifyIcons
+        {
+            get
+            {
+                return _invertNotifyIcons;
+            }
+            set
+            {
+                if (_invertNotifyIcons != value)
+                {
+                    _invertNotifyIcons = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
         private string[] _pinnedNotifyIcons = { "7820ae76-23e3-4229-82c1-e41cb67d5b9c", "7820ae75-23e3-4229-82c1-e41cb67d5b9c", "7820ae74-23e3-4229-82c1-e41cb67d5b9c", "7820ae73-23e3-4229-82c1-e41cb67d5b9c" };
         public string[] PinnedNotifyIcons
         {
@@ -426,7 +445,7 @@ namespace RetroBar.Utilities
             }
         }
 
-        private InvertIconsOption _invertIconsMode = InvertIconsOption.WhenNeededByTheme;
+        private InvertIconsOption _invertIconsMode = EnvironmentHelper.IsWindows10OrBetter ? InvertIconsOption.WhenNeededByTheme : InvertIconsOption.Never;
         public InvertIconsOption InvertIconsMode
         {
             get


### PR DESCRIPTION
The "Customize Notifications" window now allows selecting whether or not an icon gets inverted (per the invert icons setting). Also, the window now shows icons in their inverted state.

If the option to collapse notify icons is not enabled, then the window adjusts to hide those options.

Removed the OS version condition and instead adjusted the default setting based on OS.

Suggested in #523 