### PR TITLE
Add more notification area icon options

### DIFF
--- a/RetroBar/App.xaml.cs
+++ b/RetroBar/App.xaml.cs
@@ -11,6 +11,7 @@ using ManagedShell.Common.Enums;
 using System.Diagnostics;
 using System.Reflection;
 using ManagedShell.Common.Logging;
+using System.Linq;
 
 namespace RetroBar
 {
@@ -110,7 +111,7 @@ namespace RetroBar
             _logger = new ManagedShellLogger();
 
             ShellConfig config = ShellManager.DefaultShellConfig;
-            config.PinnedNotifyIcons = Settings.Instance.PinnedNotifyIcons;
+            config.PinnedNotifyIcons = Settings.Instance.NotifyIconBehaviors.Where(setting => setting.Behavior == NotifyIconBehavior.AlwaysShow).Select(setting => setting.Identifier).ToArray();
 
             return new ShellManager(config);
         }

--- a/RetroBar/Controls/NotifyIcon.xaml.cs
+++ b/RetroBar/Controls/NotifyIcon.xaml.cs
@@ -34,7 +34,7 @@ namespace RetroBar.Controls
 
         private void applyEffects()
         {
-            if (TrayIcon == null || Settings.Instance.InvertIconsMode == Settings.InvertIconsOption.Never)
+            if (TrayIcon == null || Settings.Instance.InvertIconsMode == InvertIconsOption.Never)
             {
                 return;
             }
@@ -45,7 +45,7 @@ namespace RetroBar.Controls
             }
 
             bool invertByTheme = Application.Current.FindResource("InvertSystemNotifyIcons") as bool? ?? false;
-            bool performInvert = invertByTheme || Settings.Instance.InvertIconsMode == Settings.InvertIconsOption.Always;
+            bool performInvert = invertByTheme || Settings.Instance.InvertIconsMode == InvertIconsOption.Always;
 
             if (NotifyIconImage.Effect == null != performInvert)
             {
@@ -102,6 +102,11 @@ namespace RetroBar.Controls
         private void TrayIcon_NotificationBalloonShown(object sender, NotificationBalloonEventArgs e)
         {
             if (Host == null || !Host.Screen.Primary)
+            {
+                return;
+            }
+
+            if (TrayIcon == null || TrayIcon.GetBehavior() == NotifyIconBehavior.AlwaysHide || TrayIcon.GetBehavior() == NotifyIconBehavior.Disabled)
             {
                 return;
             }

--- a/RetroBar/Controls/NotifyIconList.xaml.cs
+++ b/RetroBar/Controls/NotifyIconList.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Threading;
 using ManagedShell.WindowsTray;
+using RetroBar.Extensions;
 using RetroBar.Utilities;
 
 namespace RetroBar.Controls
@@ -75,6 +76,7 @@ namespace RetroBar.Controls
                 allNotifyIcons.Add(new CollectionContainer { Collection = NotificationArea.UnpinnedIcons });
                 allNotifyIcons.Add(new CollectionContainer { Collection = NotificationArea.PinnedIcons });
                 allNotifyIconsSource = new CollectionViewSource { Source = allNotifyIcons };
+                NotificationArea.UnpinnedIcons.Filter = UnpinnedNotifyIcons_Filter;
 
                 CompositeCollection pinnedNotifyIcons = new CompositeCollection();
                 pinnedNotifyIcons.Add(new CollectionContainer { Collection = promotedIcons });
@@ -105,6 +107,16 @@ namespace RetroBar.Controls
             }
         }
 
+        private bool UnpinnedNotifyIcons_Filter(object obj)
+        {
+            if (obj is ManagedShell.WindowsTray.NotifyIcon notifyIcon)
+            {
+                return !notifyIcon.IsPinned && !notifyIcon.IsHidden && notifyIcon.GetBehavior() != NotifyIconBehavior.Disabled;
+            }
+
+            return true;
+        }
+
         private void NotificationArea_NotificationBalloonShown(object sender, NotificationBalloonEventArgs e)
         {
             // This is used to promote unpinned icons to show when the tray is collapsed.
@@ -119,6 +131,12 @@ namespace RetroBar.Controls
             if (NotificationArea.PinnedIcons.Contains(notifyIcon))
             {
                 // Do not promote pinned icons (they're already there!)
+                return;
+            }
+
+            if (notifyIcon.GetBehavior() != NotifyIconBehavior.HideWhenInactive)
+            {
+                // Do not promote icons that are always hidden
                 return;
             }
 

--- a/RetroBar/Controls/TaskButton.xaml.cs
+++ b/RetroBar/Controls/TaskButton.xaml.cs
@@ -178,11 +178,11 @@ namespace RetroBar.Controls
         {
             if (e.ChangedButton == MouseButton.Middle)
             {
-                if (Window == null || Settings.Instance.TaskMiddleClickAction == Settings.TaskMiddleClickOption.DoNothing)
+                if (Window == null || Settings.Instance.TaskMiddleClickAction == TaskMiddleClickOption.DoNothing)
                 {
                     return;
                 }
-                if (Settings.Instance.TaskMiddleClickAction == Settings.TaskMiddleClickOption.CloseTask)
+                if (Settings.Instance.TaskMiddleClickAction == TaskMiddleClickOption.CloseTask)
                 {
                     Window?.Close();
                 }

--- a/RetroBar/Controls/TaskList.xaml.cs
+++ b/RetroBar/Controls/TaskList.xaml.cs
@@ -98,7 +98,7 @@ namespace RetroBar.Controls
             }
             else if (e.PropertyName == nameof(Settings.ShowMultiMon))
             {
-                if (Settings.Instance.MultiMonMode != Settings.MultiMonOption.AllTaskbars)
+                if (Settings.Instance.MultiMonMode != MultiMonOption.AllTaskbars)
                 {
                     taskbarItems?.Refresh();
                 }
@@ -114,12 +114,12 @@ namespace RetroBar.Controls
                     return false;
                 }
 
-                if (!Settings.Instance.ShowMultiMon || Settings.Instance.MultiMonMode == Settings.MultiMonOption.AllTaskbars)
+                if (!Settings.Instance.ShowMultiMon || Settings.Instance.MultiMonMode == MultiMonOption.AllTaskbars)
                 {
                     return true;
                 }
 
-                if (Settings.Instance.MultiMonMode == Settings.MultiMonOption.SameAsWindowAndPrimary && Host.Screen.Primary)
+                if (Settings.Instance.MultiMonMode == MultiMonOption.SameAsWindowAndPrimary && Host.Screen.Primary)
                 {
                     return true;
                 }

--- a/RetroBar/Converters/NotifyIconBehaviorConverter.cs
+++ b/RetroBar/Converters/NotifyIconBehaviorConverter.cs
@@ -1,0 +1,26 @@
+﻿using ManagedShell.WindowsTray;
+using RetroBar.Extensions;
+using System;
+using System.Windows.Data;
+
+namespace RetroBar.Converters
+{
+    [ValueConversion(typeof(NotifyIcon), typeof(int))]
+    public class NotifyIconBehaviorConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value is NotifyIcon icon)
+            {
+                return (int)icon.GetBehavior();
+            }
+
+            return Binding.DoNothing;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return Binding.DoNothing;
+        }
+    }
+}

--- a/RetroBar/Extensions/NotifyIconExtensions.cs
+++ b/RetroBar/Extensions/NotifyIconExtensions.cs
@@ -34,11 +34,19 @@ namespace RetroBar.Extensions
 
             if (currentSettingIndex >= 0)
             {
-                settings[currentSettingIndex] = new NotifyIconBehaviorSetting
+                if (behavior == NotifyIconBehavior.HideWhenInactive)
                 {
-                    Identifier = icon.Identifier,
-                    Behavior = behavior
-                };
+                    // Switching back to default value; remove from settings
+                    settings.RemoveAt(currentSettingIndex);
+                }
+                else
+                {
+                    settings[currentSettingIndex] = new NotifyIconBehaviorSetting
+                    {
+                        Identifier = icon.Identifier,
+                        Behavior = behavior
+                    };
+                }
             }
             else
             {
@@ -50,7 +58,24 @@ namespace RetroBar.Extensions
             }
 
             Settings.Instance.NotifyIconBehaviors = settings;
-            icon.OnPropertyChanged("IsPinned");
+
+            if (icon.IsPinned != (behavior == NotifyIconBehavior.AlwaysShow))
+            {
+                // Update pinned values in ManagedShell
+                if (behavior == NotifyIconBehavior.AlwaysShow)
+                {
+                    icon.Pin();
+                }
+                else
+                {
+                    icon.Unpin();
+                }
+            }
+            else
+            {
+                // Trigger a refresh of the collections
+                icon.OnPropertyChanged("IsPinned");
+            }
         }
 
         public static bool CanInvert(this NotifyIcon icon) {

--- a/RetroBar/Extensions/NotifyIconExtensions.cs
+++ b/RetroBar/Extensions/NotifyIconExtensions.cs
@@ -12,6 +12,47 @@ namespace RetroBar.Extensions
             else return icon.Path + ":" + icon.UID.ToString();
         }
 
+        public static NotifyIconBehavior GetBehavior(this NotifyIcon icon)
+        {
+            if (icon.IsPinned)
+            {
+                return NotifyIconBehavior.AlwaysShow;
+            }
+
+            if (Settings.Instance.NotifyIconBehaviors.Find(setting => setting.Identifier == icon.Identifier) is NotifyIconBehaviorSetting iconSetting)
+            {
+                return iconSetting.Behavior;
+            }
+
+            return NotifyIconBehavior.HideWhenInactive;
+        }
+
+        public static void SetBehavior(this NotifyIcon icon, NotifyIconBehavior behavior)
+        {
+            var settings = new List<NotifyIconBehaviorSetting>(Settings.Instance.NotifyIconBehaviors);
+            var currentSettingIndex = settings.FindIndex(setting => setting.Identifier == icon.Identifier);
+
+            if (currentSettingIndex >= 0)
+            {
+                settings[currentSettingIndex] = new NotifyIconBehaviorSetting
+                {
+                    Identifier = icon.Identifier,
+                    Behavior = behavior
+                };
+            }
+            else
+            {
+                settings.Add(new NotifyIconBehaviorSetting
+                {
+                    Identifier = icon.Identifier,
+                    Behavior = behavior
+                });
+            }
+
+            Settings.Instance.NotifyIconBehaviors = settings;
+            icon.OnPropertyChanged("IsPinned");
+        }
+
         public static bool CanInvert(this NotifyIcon icon) {
             return Settings.Instance.InvertNotifyIcons.Contains(icon.GetInvertIdentifier());
         }

--- a/RetroBar/Languages/English.xaml
+++ b/RetroBar/Languages/English.xaml
@@ -69,6 +69,8 @@
     <s:String x:Key="customize_notifications_instruction">Select an item, then choose its notification behavior:</s:String>
     <s:String x:Key="hide_when_inactive">Hide when inactive</s:String>
     <s:String x:Key="always_show">Always show</s:String>
+    <s:String x:Key="always_hide">Always hide</s:String>
+    <s:String x:Key="disabled">Disabled</s:String>
     <s:String x:Key="name_heading">Name</s:String>
     <s:String x:Key="behavior_heading">Behavior</s:String>
     <s:String x:Key="invert_heading">Invert</s:String>

--- a/RetroBar/NotificationPropertiesWindow.xaml
+++ b/RetroBar/NotificationPropertiesWindow.xaml
@@ -15,6 +15,7 @@
             <converters:BoolToIntConverter x:Key="boolToIntConverter" />
             <converters:BoolToVisibilityConverter x:Key="boolToVisibilityConverter" />
             <converters:NewLineToSpaceConverter x:Key="newLineToSpaceConverter" />
+            <converters:NotifyIconBehaviorConverter x:Key="notifyIconBehaviorConverter" />
             <converters:NotifyIconCanInvertConverter x:Key="notifyIconCanInvertConverter" />
             <Style TargetType="{x:Type ComboBox}">
                 <Setter Property="HorizontalAlignment"
@@ -100,22 +101,30 @@
                                             <TextBlock.Style>
                                                 <Style TargetType="TextBlock">
                                                     <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding IsPinned}" Value="True">
+                                                        <DataTrigger Binding="{Binding Converter={StaticResource notifyIconBehaviorConverter}}" Value="0">
+                                                            <Setter Property="Text" Value="{DynamicResource hide_when_inactive}" />
+                                                        </DataTrigger>
+                                                        <DataTrigger Binding="{Binding Converter={StaticResource notifyIconBehaviorConverter}}" Value="1">
+                                                            <Setter Property="Text" Value="{DynamicResource always_hide}" />
+                                                        </DataTrigger>
+                                                        <DataTrigger Binding="{Binding Converter={StaticResource notifyIconBehaviorConverter}}" Value="2">
                                                             <Setter Property="Text" Value="{DynamicResource always_show}" />
                                                         </DataTrigger>
-                                                        <DataTrigger Binding="{Binding IsPinned}" Value="False">
-                                                            <Setter Property="Text" Value="{DynamicResource hide_when_inactive}" />
+                                                        <DataTrigger Binding="{Binding Converter={StaticResource notifyIconBehaviorConverter}}" Value="3">
+                                                            <Setter Property="Text" Value="{DynamicResource disabled}" />
                                                         </DataTrigger>
                                                     </Style.Triggers>
                                                 </Style>
                                             </TextBlock.Style>
                                         </TextBlock>
                                         <ComboBox Name="BehaviorComboBox"
-                                                  SelectedIndex="{Binding IsPinned, Converter={StaticResource boolToIntConverter}}"
+                                                  SelectedIndex="{Binding Mode=OneWay, Converter={StaticResource notifyIconBehaviorConverter}}"
                                                   SelectionChanged="BehaviorComboBox_SelectionChanged"
                                                   Visibility="Collapsed">
-                                            <ComboBoxItem Content="{DynamicResource hide_when_inactive}" />
-                                            <ComboBoxItem Content="{DynamicResource always_show}" />
+                                            <ComboBoxItem Content="{DynamicResource hide_when_inactive}" Tag="{x:Static Settings:NotifyIconBehavior.HideWhenInactive}" />
+                                            <ComboBoxItem Content="{DynamicResource always_hide}" Tag="{x:Static Settings:NotifyIconBehavior.AlwaysHide}" />
+                                            <ComboBoxItem Content="{DynamicResource always_show}" Tag="{x:Static Settings:NotifyIconBehavior.AlwaysShow}" />
+                                            <ComboBoxItem Content="{DynamicResource disabled}" Tag="{x:Static Settings:NotifyIconBehavior.Disabled}" />
                                         </ComboBox>
                                     </StackPanel>
                                     <DataTemplate.Triggers>

--- a/RetroBar/NotificationPropertiesWindow.xaml.cs
+++ b/RetroBar/NotificationPropertiesWindow.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using ManagedShell.WindowsTray;
 using RetroBar.Extensions;
 using RetroBar.Utilities;
-using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -76,7 +75,6 @@ namespace RetroBar
                 }
 
                 notifyIcon.SetBehavior(behavior);
-                _notificationArea.SetPinnedIcons(Settings.Instance.NotifyIconBehaviors.Where(setting => setting.Behavior == NotifyIconBehavior.AlwaysShow).Select(setting => setting.Identifier).ToArray());
             }
         }
 

--- a/RetroBar/NotificationPropertiesWindow.xaml.cs
+++ b/RetroBar/NotificationPropertiesWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using ManagedShell.WindowsTray;
 using RetroBar.Extensions;
 using RetroBar.Utilities;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -27,7 +28,7 @@ namespace RetroBar
 
         private void Settings_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == "InvertNotifyIcons")
+            if (e.PropertyName == nameof(Settings.InvertNotifyIcons) || e.PropertyName == nameof(Settings.NotifyIconBehaviors))
             {
                 // Reload icons
                 DataContext = null;
@@ -63,7 +64,20 @@ namespace RetroBar
 
         private void BehaviorComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            Settings.Instance.PinnedNotifyIcons = _notificationArea.PinnedNotifyIcons;
+            if (e.AddedItems.Count > 0 && 
+                (sender as FrameworkElement).DataContext is NotifyIcon notifyIcon && 
+                e.AddedItems[0] is ComboBoxItem selected && 
+                selected.Tag is NotifyIconBehavior behavior)
+            {
+                if (notifyIcon.GetBehavior() == behavior)
+                {
+                    // Same setting selected; do nothing
+                    return;
+                }
+
+                notifyIcon.SetBehavior(behavior);
+                _notificationArea.SetPinnedIcons(Settings.Instance.NotifyIconBehaviors.Where(setting => setting.Behavior == NotifyIconBehavior.AlwaysShow).Select(setting => setting.Identifier).ToArray());
+            }
         }
 
         private void InvertCheckBox_Checked(object sender, RoutedEventArgs e)

--- a/RetroBar/Utilities/Settings.cs
+++ b/RetroBar/Utilities/Settings.cs
@@ -174,11 +174,33 @@ namespace RetroBar.Utilities
             set => Set(ref _invertNotifyIcons, value);
         }
 
-        private string[] _pinnedNotifyIcons = ["7820ae76-23e3-4229-82c1-e41cb67d5b9c", "7820ae75-23e3-4229-82c1-e41cb67d5b9c", "7820ae74-23e3-4229-82c1-e41cb67d5b9c", "7820ae73-23e3-4229-82c1-e41cb67d5b9c"];
-        public string[] PinnedNotifyIcons
+        private List<NotifyIconBehaviorSetting> _notifyIconBehaviors = new List<NotifyIconBehaviorSetting>
         {
-            get => _pinnedNotifyIcons;
-            set => Set(ref _pinnedNotifyIcons, value);
+            new NotifyIconBehaviorSetting
+            {
+                Identifier = NotificationArea.HEALTH_GUID,
+                Behavior = NotifyIconBehavior.AlwaysShow
+            },
+            new NotifyIconBehaviorSetting
+            {
+                Identifier = NotificationArea.POWER_GUID,
+                Behavior = NotifyIconBehavior.AlwaysShow
+            },
+            new NotifyIconBehaviorSetting
+            {
+                Identifier = NotificationArea.NETWORK_GUID,
+                Behavior = NotifyIconBehavior.AlwaysShow
+            },
+            new NotifyIconBehaviorSetting
+            {
+                Identifier = NotificationArea.VOLUME_GUID,
+                Behavior = NotifyIconBehavior.AlwaysShow
+            },
+        };
+        public List<NotifyIconBehaviorSetting> NotifyIconBehaviors
+        {
+            get => _notifyIconBehaviors;
+            set => Set(ref _notifyIconBehaviors, value);
         }
 
         private bool _allowFontSmoothing = false;
@@ -279,28 +301,42 @@ namespace RetroBar.Utilities
             set => Set(ref _updates, value);
         }
         #endregion
+    }
 
-        #region Enums
-        public enum InvertIconsOption
-        {
-            WhenNeededByTheme,
-            Always,
-            Never
-        }
+    #region Enums
+    public enum InvertIconsOption
+    {
+        WhenNeededByTheme,
+        Always,
+        Never
+    }
 
-        public enum MultiMonOption
-        {
-            AllTaskbars,
-            SameAsWindow,
-            SameAsWindowAndPrimary
-        }
+    public enum MultiMonOption
+    {
+        AllTaskbars,
+        SameAsWindow,
+        SameAsWindowAndPrimary
+    }
 
-        public enum TaskMiddleClickOption
-        {
-            DoNothing,
-            OpenNewInstance,
-            CloseTask
-        }
-        #endregion
+    public enum TaskMiddleClickOption
+    {
+        DoNothing,
+        OpenNewInstance,
+        CloseTask
+    }
+
+    public enum NotifyIconBehavior
+    {
+        HideWhenInactive,
+        AlwaysHide,
+        AlwaysShow,
+        Disabled
+    }
+    #endregion
+
+    public struct NotifyIconBehaviorSetting
+    {
+        public string Identifier {  get; set; }
+        public NotifyIconBehavior Behavior { get; set; }
     }
 }

--- a/RetroBar/Utilities/SettingsManager.cs
+++ b/RetroBar/Utilities/SettingsManager.cs
@@ -8,7 +8,7 @@ using System.Text.Json;
 
 namespace RetroBar.Utilities
 {
-    public class SettingsManager<T> : INotifyPropertyChanged where T : new()
+    public class SettingsManager<T> : INotifyPropertyChanged where T : IMigratableSettings
     {
         public event PropertyChangedEventHandler PropertyChanged;
 
@@ -48,6 +48,13 @@ namespace RetroBar.Utilities
 
                 string jsonString = File.ReadAllText(_fileName);
                 _settings = JsonSerializer.Deserialize<T>(jsonString);
+
+                if (_settings.MigrationPerformed)
+                {
+                    // Save post-migration state so that we don't need to migrate every startup
+                    SaveToFile();
+                }
+
                 return true;
             }
             catch (Exception ex)
@@ -83,5 +90,10 @@ namespace RetroBar.Utilities
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
+    }
+
+    public interface IMigratableSettings
+    {
+        public bool MigrationPerformed { get; }
     }
 }


### PR DESCRIPTION
- Added "Always hide" option which acts the same as "hide when inactive", but does not promote the icon or show a bubble notification when the icon is supposed to show an alert.
- Added "Disabled" option which hides the icon from the tray completely (fixes #338 and others)
- Created a new struct to hold the behavior settings for each icon and added logic to migrate from the old PinnedNotifyIcons setting