### PR TITLE
Simple API to change settings

### DIFF
--- a/RetroBar/Api/Api.cs
+++ b/RetroBar/Api/Api.cs
@@ -20,9 +20,9 @@ public class Api
         listener.Start();
         Task.Run(async () =>
         {
-            while (true)
+            while (true) // only loops once per api call
             {
-                HttpListenerContext context = await listener.GetContextAsync();
+                HttpListenerContext context = await listener.GetContextAsync(); // GetContextAsync waits for an api call
                 HttpListenerRequest request = context.Request;
                 HttpListenerResponse response = context.Response;
                 response.StatusCode = 200;

--- a/RetroBar/Api/Api.cs
+++ b/RetroBar/Api/Api.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using System.Windows;
+using Microsoft.AspNetCore.JsonPatch;
+using Microsoft.AspNetCore.JsonPatch.Operations;
+using Newtonsoft.Json.Serialization;
+using RetroBar.Utilities;
+
+namespace RetroBar.Api;
+
+public class Api
+{
+    public static void StartListening()
+    {
+        HttpListener listener = new();
+        listener.Prefixes.Add ("http://localhost:51111/"); // Listen on 51111
+        listener.Start();
+        Task.Run(async () =>
+        {
+            while (true)
+            {
+                HttpListenerContext context = await listener.GetContextAsync();
+                HttpListenerRequest request = context.Request;
+                using (StreamReader reader = new(request.InputStream, request.ContentEncoding))
+                {
+                    string jsonPatchString = await reader.ReadToEndAsync();
+                    var operations = Newtonsoft.Json.JsonConvert.DeserializeObject<List<Operation>>(jsonPatchString);
+                    JsonPatchDocument patch = new(operations, new DefaultContractResolver());
+                    Application.Current.Dispatcher.Invoke(delegate
+                    {
+                        patch.ApplyTo(Settings.Instance);
+                    });
+                }
+                HttpListenerResponse response = context.Response;
+                response.StatusCode = 200;
+                response.Close();
+            }
+        });
+    }
+}

--- a/RetroBar/App.xaml.cs
+++ b/RetroBar/App.xaml.cs
@@ -57,7 +57,11 @@ namespace RetroBar
             DictionaryManager.SetLanguageFromSettings();
             loadTheme();
             _windowManager = new WindowManager(_shellManager, _startMenuMonitor, _updater);
-            Api.Api.StartListening();
+            
+            if (Settings.Instance.UseApi)
+            {
+                Api.Api.StartListening();
+            }
         }
 
         private void App_OnExit(object sender, ExitEventArgs e)

--- a/RetroBar/App.xaml.cs
+++ b/RetroBar/App.xaml.cs
@@ -57,6 +57,7 @@ namespace RetroBar
             DictionaryManager.SetLanguageFromSettings();
             loadTheme();
             _windowManager = new WindowManager(_shellManager, _startMenuMonitor, _updater);
+            Api.Api.StartListening();
         }
 
         private void App_OnExit(object sender, ExitEventArgs e)

--- a/RetroBar/RetroBar.csproj
+++ b/RetroBar/RetroBar.csproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <PackageReference Include="gong-wpf-dragdrop" Version="3.1.1" />
     <PackageReference Include="ManagedShell" Version="0.0.249" />
+    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.31" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
   </ItemGroup>
 

--- a/RetroBar/Utilities/Settings.cs
+++ b/RetroBar/Utilities/Settings.cs
@@ -286,6 +286,20 @@ namespace RetroBar.Utilities
             get => _checkForUpdates;
             set => Set(ref _checkForUpdates, value);
         }
+        
+        private bool _useApi = false;
+        public bool UseApi
+        {
+            get => _useApi;
+            set => Set(ref _useApi, value);
+        }
+        
+        private int _apiPort = 51111;
+        public int ApiPort
+        {
+            get => _apiPort;
+            set => Set(ref _apiPort, value);
+        }
         #endregion
 
         #region Old Properties


### PR DESCRIPTION
This PR implements a feature described in Issue #864

This adds:
A [JSON Patch](https://jsonpatch.com/) API that can be used to change any settings at runtime through an API.
Two new settings (not visible in GUI): bool UseApi (off by default, as this feature should be opt-in), and int ApiPort (the port to be used by the API, default 51111)

Example of an API call to change the theme to "Windows XP Silver":
`PATCH http://localhost:51111`
```
[
  {
    "op": "replace",
    "path": "/Theme",
    "value": "Windows XP Silver"
  }
]
```