### PR TITLE
Fix row count setting

### DIFF
--- a/RetroBar/Converters/CountToIndexConverter.cs
+++ b/RetroBar/Converters/CountToIndexConverter.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace RetroBar.Converters
+{
+    public class CountToIndexConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return (int)value - 1;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return (int)value + 1;
+        }
+    }
+}

--- a/RetroBar/PropertiesWindow.xaml
+++ b/RetroBar/PropertiesWindow.xaml
@@ -21,6 +21,7 @@
             <converters:BoolToTextRenderingModeConverter x:Key="textRenderingModeConverter" />
             <converters:BoolToVisibilityConverter x:Key="boolToVisibilityConverter" />
             <converters:BoolToInvertedVisibilityConverter x:Key="boolToInvertedVisibilityConverter" />
+            <converters:CountToIndexConverter x:Key="countToIndexConverter" />
             <converters:DoubleToPercentConverter x:Key="doubleToPercentConverter" />
             <converters:EnumConverter x:Key="enumConverter" />
             <converters:EdgeIsHorizontalConverter x:Key="isHorizontalConverter" />
@@ -212,7 +213,8 @@
                                 </Label>
                                 <ComboBox x:Name="cbRowCount"
                                           ItemsSource="{DynamicResource rowcount_options}"
-                                          SelectedValue="{Binding Source={x:Static Settings:Settings.Instance}, Path=RowCount, UpdateSourceTrigger=PropertyChanged}" />
+                                          SelectedIndex="{Binding Source={x:Static Settings:Settings.Instance}, Path=RowCount, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource countToIndexConverter}}"
+                                          SelectionChanged="cbRowCount_SelectionChanged" />
                             </DockPanel>
                             <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=AllowFontSmoothing, UpdateSourceTrigger=PropertyChanged}">
                                 <Label Content="{DynamicResource allow_font_smoothing}" />

--- a/RetroBar/PropertiesWindow.xaml.cs
+++ b/RetroBar/PropertiesWindow.xaml.cs
@@ -290,6 +290,14 @@ namespace RetroBar
             }
         }
 
+        private void cbRowCount_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            if (cbRowCount.SelectedItem == null)
+            {
+                cbRowCount.SelectedValue = cbRowCount.Items[Settings.Instance.RowCount - 1];
+            }
+        }
+
         private void CustomizeNotifications_OnClick(object sender, RoutedEventArgs e)
         {
             OpenCustomizeNotifications();


### PR DESCRIPTION
The localized options are now used for display purposes only, rather than holding the actual setting.