### PR TITLE
Implement Explorer.exe monitoring feature.

### DIFF
--- a/RetroBar/Utilities/ExplorerMonitor.cs
+++ b/RetroBar/Utilities/ExplorerMonitor.cs
@@ -7,46 +7,40 @@ namespace RetroBar.Utilities
 {
     public class ExplorerMonitor : IDisposable
     {
-        private bool _ExplorerMonitorIsMonitoring;
-        private MonitorWindow _explorerMonitor;
+        private bool _explorerMonitorisMonitoring;
+        private ExplorerMonitorWindow _explorerMonitorWindow;
 
-        public void ExplorerMonitorStart(WindowManager _windowManagerReference)
+        public void ExplorerMonitorStart(WindowManager windowManagerRef)
         {
-            if(_ExplorerMonitorIsMonitoring) // Prevent multiple monitors.
-            {
-                return;
-            }
-            else
-            {
-                _ExplorerMonitorIsMonitoring = true; // We will set flag to true to prevent multiple monitors.
-                _explorerMonitor = new MonitorWindow(_windowManagerReference); // Start monitoring.
-            }
+            if (_explorerMonitorisMonitoring) { return; } // Prevent multiple monitors.
+
+            _explorerMonitorisMonitoring = true;
+            _explorerMonitorWindow = new ExplorerMonitorWindow(windowManagerRef); // Start monitoring.
         }
 
         public void Dispose()
         {
-            if (_explorerMonitor != null){_explorerMonitor?.Dispose();}
+            _explorerMonitorWindow?.Dispose();
         }
 
-        // NativeWindow implementation for monitoring
-        private class MonitorWindow : NativeWindow, IDisposable
+        private class ExplorerMonitorWindow : NativeWindow, IDisposable
         {
-            private WindowManager _windowManager;
-            private static readonly int TaskbarCreatedMessage = NativeMethods.RegisterWindowMessage("TaskbarCreated");
+            private readonly WindowManager _windowManagerRef;
+            private static readonly int WM_TASKBARCREATEDMESSAGE = NativeMethods.RegisterWindowMessage("TaskbarCreated");
 
-            public MonitorWindow(WindowManager _windowManagerReference)
+            public ExplorerMonitorWindow(WindowManager windowManager)
             {
-                _windowManager = _windowManagerReference;
+                _windowManagerRef = windowManager;
                 CreateHandle(new CreateParams());
             }
 
             protected override void WndProc(ref Message m)
             {
-                if (m.Msg == TaskbarCreatedMessage)
+                if (m.Msg == WM_TASKBARCREATEDMESSAGE)
                 {
                     try
                     {
-                        _windowManager.ReopenTaskbars(); // Reopen taskbars if explorer.exe is restarted.
+                        _windowManagerRef.ReopenTaskbars();
                     }
                     catch (Exception ex)
                     {
@@ -54,7 +48,6 @@ namespace RetroBar.Utilities
                     }
                 }
 
-                // Call the base class to process other messages so we dont accidentally cause crashes or bugs.
                 base.WndProc(ref m);
             }
 

--- a/RetroBar/Utilities/ExplorerMonitor.cs
+++ b/RetroBar/Utilities/ExplorerMonitor.cs
@@ -1,14 +1,14 @@
+using ManagedShell.Interop;
 using System;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
 namespace RetroBar.Utilities
 {
     public class ExplorerMonitor : IDisposable
     {
-        private volatile bool _ExplorerMonitorIsMonitoring;
-        private _ExplorerMonitor _explorerMonitor;
+        private bool _ExplorerMonitorIsMonitoring;
+        private MonitorWindow _explorerMonitor;
 
         public void ExplorerMonitorStart()
         {
@@ -19,67 +19,52 @@ namespace RetroBar.Utilities
             else
             {
                 _ExplorerMonitorIsMonitoring = true; // We will set flag to true to prevent multiple monitors.
-
-                // Start monitoring
-                _explorerMonitor = new _ExplorerMonitor();
-                _explorerMonitor.Show();
-            }
-        }
-
-        // ExplorerMonitor is a hidden form that captures taskbar events
-        private class _ExplorerMonitor : Form
-        {
-            private const int GWL_EXSTYLE = -20;
-            private const int WS_EX_TOOLWINDOW = 0x00000080;
-            private const int WS_EX_APPWINDOW = 0x00040000;
-
-            [DllImport("user32.dll", SetLastError = true)] private static extern uint RegisterWindowMessage(string lpString);
-            [DllImport("user32.dll")] private static extern IntPtr SetWindowLong(IntPtr hwnd, int index, int newStyle);
-            [DllImport("user32.dll")] private static extern int GetWindowLong(IntPtr hwnd, int index);
-
-            public _ExplorerMonitor()
-            {
-                // These will make the ExplorerMonitor form completely invisible, so we can use it just as a monitor and not form
-                ClientSize = new System.Drawing.Size(1, 1); // Set the size to 1x1 pixel (tiny and invisible)
-                FormBorderStyle = FormBorderStyle.None; // Make the form borderless
-                BackColor = System.Drawing.Color.Lime;  // Use a color thats fully transparent in the form
-                TransparencyKey = System.Drawing.Color.Lime; // Set transparency key to make the color transparent
-                ShowInTaskbar = false; // Ensure the form doesnt appear in the taskbar
-                ControlBox = false; // Ensure no controls (like buttons) are on the form
-                Visible = false; // Set the form as invisible
-                StartPosition = FormStartPosition.Manual; // Dont center this form
-                Location = new System.Drawing.Point(-1000, -1000); // Move it far off-screen
-
-                // Remove ExplorerMonitor from the Alt+Tab list by modifying its extended style
-                int extendedStyle = GetWindowLong(this.Handle, GWL_EXSTYLE);
-                SetWindowLong(this.Handle, GWL_EXSTYLE, extendedStyle | WS_EX_TOOLWINDOW);
-            }
-
-            // We will override WndProc to listen for TaskbarCreated event
-            protected override void WndProc(ref Message m)
-            {
-                if (m.Msg == (int)RegisterWindowMessage("TaskbarCreated"))
-                {
-                    try
-                    {
-                        string appPath = Process.GetCurrentProcess().MainModule?.FileName;
-                        Process.Start(appPath); // Start a new instance of RetroBar
-                        Environment.Exit(0); // Exit the current instance of RetroBar
-                    }
-                    catch (Exception ex)
-                    {
-                        Console.WriteLine($"Error restarting RetroBar: {ex.Message}");
-                    }
-                }
-
-                // Call the base class to process other messages so we dont accidentally cause crashes or bugs.
-                base.WndProc(ref m);
+                _explorerMonitor = new MonitorWindow(); // Start monitoring.
             }
         }
 
         public void Dispose()
         {
             if (_explorerMonitor != null){_explorerMonitor?.Dispose();}
+        }
+
+        // NativeWindow implementation for monitoring
+        private class MonitorWindow : NativeWindow, IDisposable
+        {
+            //private readonly WindowManager _windowManager;
+            private static readonly int TaskbarCreatedMessage = NativeMethods.RegisterWindowMessage("TaskbarCreated");
+
+            public MonitorWindow()
+            {
+                CreateHandle(new CreateParams());
+            }
+
+            protected override void WndProc(ref Message m)
+            {
+                if (m.Msg == TaskbarCreatedMessage)
+                {
+                    try
+                    {
+                        //_windowManager.ReopenTaskbars(); // Reopen taskbars if explorer.exe is restarted.
+                        string appPath = Process.GetCurrentProcess().MainModule?.FileName;
+                        Process.Start(appPath); // Start a new instance of RetroBar
+                        Environment.Exit(0); // Exit the current instance of RetroBar
+                    }
+                    catch (Exception ex)
+                    {
+                        //Debug.WriteLine($"Error handling TaskbarCreated message on ExplorerMonitor: {ex.Message}");
+                        Debug.WriteLine($"Error restarting RetroBar: {ex.Message}");
+                    }
+                }
+
+                // Call the base class to process other messages so we dont accidentally cause crashes or bugs.
+                base.WndProc(ref m);
+            }
+
+            public void Dispose()
+            {
+                DestroyHandle();
+            }
         }
     }
 }

--- a/RetroBar/Utilities/ExplorerMonitor.cs
+++ b/RetroBar/Utilities/ExplorerMonitor.cs
@@ -10,7 +10,7 @@ namespace RetroBar.Utilities
         private bool _ExplorerMonitorIsMonitoring;
         private MonitorWindow _explorerMonitor;
 
-        public void ExplorerMonitorStart()
+        public void ExplorerMonitorStart(WindowManager _windowManagerReference)
         {
             if(_ExplorerMonitorIsMonitoring) // Prevent multiple monitors.
             {
@@ -19,7 +19,7 @@ namespace RetroBar.Utilities
             else
             {
                 _ExplorerMonitorIsMonitoring = true; // We will set flag to true to prevent multiple monitors.
-                _explorerMonitor = new MonitorWindow(); // Start monitoring.
+                _explorerMonitor = new MonitorWindow(_windowManagerReference); // Start monitoring.
             }
         }
 
@@ -31,11 +31,12 @@ namespace RetroBar.Utilities
         // NativeWindow implementation for monitoring
         private class MonitorWindow : NativeWindow, IDisposable
         {
-            //private readonly WindowManager _windowManager;
+            private WindowManager _windowManager;
             private static readonly int TaskbarCreatedMessage = NativeMethods.RegisterWindowMessage("TaskbarCreated");
 
-            public MonitorWindow()
+            public MonitorWindow(WindowManager _windowManagerReference)
             {
+                _windowManager = _windowManagerReference;
                 CreateHandle(new CreateParams());
             }
 
@@ -45,15 +46,11 @@ namespace RetroBar.Utilities
                 {
                     try
                     {
-                        //_windowManager.ReopenTaskbars(); // Reopen taskbars if explorer.exe is restarted.
-                        string appPath = Process.GetCurrentProcess().MainModule?.FileName;
-                        Process.Start(appPath); // Start a new instance of RetroBar
-                        Environment.Exit(0); // Exit the current instance of RetroBar
+                        _windowManager.ReopenTaskbars(); // Reopen taskbars if explorer.exe is restarted.
                     }
                     catch (Exception ex)
                     {
-                        //Debug.WriteLine($"Error handling TaskbarCreated message on ExplorerMonitor: {ex.Message}");
-                        Debug.WriteLine($"Error restarting RetroBar: {ex.Message}");
+                        Debug.WriteLine($"Error handling TaskbarCreated message on ExplorerMonitor: {ex.Message}");
                     }
                 }
 

--- a/RetroBar/Utilities/ExplorerMonitor.cs
+++ b/RetroBar/Utilities/ExplorerMonitor.cs
@@ -1,20 +1,18 @@
+using ManagedShell.Common.Logging;
 using ManagedShell.Interop;
 using System;
-using System.Diagnostics;
 using System.Windows.Forms;
 
 namespace RetroBar.Utilities
 {
     public class ExplorerMonitor : IDisposable
     {
-        private bool _explorerMonitorisMonitoring;
         private ExplorerMonitorWindow _explorerMonitorWindow;
 
         public void ExplorerMonitorStart(WindowManager windowManagerRef)
         {
-            if (_explorerMonitorisMonitoring) { return; } // Prevent multiple monitors.
+            if (_explorerMonitorWindow != null) { return; } // Prevent multiple monitors.
 
-            _explorerMonitorisMonitoring = true;
             _explorerMonitorWindow = new ExplorerMonitorWindow(windowManagerRef); // Start monitoring.
         }
 
@@ -28,9 +26,9 @@ namespace RetroBar.Utilities
             private readonly WindowManager _windowManagerRef;
             private static readonly int WM_TASKBARCREATEDMESSAGE = NativeMethods.RegisterWindowMessage("TaskbarCreated");
 
-            public ExplorerMonitorWindow(WindowManager windowManager)
+            public ExplorerMonitorWindow(WindowManager windowManagerRef)
             {
-                _windowManagerRef = windowManager;
+                _windowManagerRef = windowManagerRef;
                 CreateHandle(new CreateParams());
             }
 
@@ -44,7 +42,7 @@ namespace RetroBar.Utilities
                     }
                     catch (Exception ex)
                     {
-                        Debug.WriteLine($"Error handling TaskbarCreated message on ExplorerMonitor: {ex.Message}");
+                        ShellLogger.Warning($"Error handling TaskbarCreated message on ExplorerMonitor: {ex.Message}");
                     }
                 }
 

--- a/RetroBar/Utilities/ExplorerMonitor.cs
+++ b/RetroBar/Utilities/ExplorerMonitor.cs
@@ -40,7 +40,7 @@ namespace RetroBar.Utilities
                 {
                     try
                     {
-                        _windowManagerRef.ReopenTaskbars();
+                        _windowManagerRef.ReopenTaskbars(); // Reopen taskbars if explorer.exe is restarted.
                     }
                     catch (Exception ex)
                     {
@@ -48,7 +48,7 @@ namespace RetroBar.Utilities
                     }
                 }
 
-                base.WndProc(ref m);
+                base.WndProc(ref m); // Call the base class to process other messages so we dont accidentally cause crashes or bugs.
             }
 
             public void Dispose()

--- a/RetroBar/Utilities/ExplorerMonitor.cs
+++ b/RetroBar/Utilities/ExplorerMonitor.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace RetroBar.Utilities
+{
+    public class ExplorerMonitor : IDisposable
+    {
+        private volatile bool _ExplorerMonitorIsMonitoring;
+        private _ExplorerMonitor _explorerMonitor;
+
+        public void ExplorerMonitorStart()
+        {
+            if(_ExplorerMonitorIsMonitoring) // Prevent multiple monitors.
+            {
+                return;
+            }
+            else
+            {
+                _ExplorerMonitorIsMonitoring = true; // We will set flag to true to prevent multiple monitors.
+
+                // Start monitoring
+                _explorerMonitor = new _ExplorerMonitor();
+                _explorerMonitor.Show();
+            }
+        }
+
+        // ExplorerMonitor is a hidden form that captures taskbar events
+        private class _ExplorerMonitor : Form
+        {
+            private const int GWL_EXSTYLE = -20;
+            private const int WS_EX_TOOLWINDOW = 0x00000080;
+            private const int WS_EX_APPWINDOW = 0x00040000;
+
+            [DllImport("user32.dll", SetLastError = true)] private static extern uint RegisterWindowMessage(string lpString);
+            [DllImport("user32.dll")] private static extern IntPtr SetWindowLong(IntPtr hwnd, int index, int newStyle);
+            [DllImport("user32.dll")] private static extern int GetWindowLong(IntPtr hwnd, int index);
+
+            public _ExplorerMonitor()
+            {
+                // These will make the ExplorerMonitor form completely invisible, so we can use it just as a monitor and not form
+                ClientSize = new System.Drawing.Size(1, 1); // Set the size to 1x1 pixel (tiny and invisible)
+                FormBorderStyle = FormBorderStyle.None; // Make the form borderless
+                BackColor = System.Drawing.Color.Lime;  // Use a color thats fully transparent in the form
+                TransparencyKey = System.Drawing.Color.Lime; // Set transparency key to make the color transparent
+                ShowInTaskbar = false; // Ensure the form doesnt appear in the taskbar
+                ControlBox = false; // Ensure no controls (like buttons) are on the form
+                Visible = false; // Set the form as invisible
+                StartPosition = FormStartPosition.Manual; // Dont center this form
+                Location = new System.Drawing.Point(-1000, -1000); // Move it far off-screen
+
+                // Remove ExplorerMonitor from the Alt+Tab list by modifying its extended style
+                int extendedStyle = GetWindowLong(this.Handle, GWL_EXSTYLE);
+                SetWindowLong(this.Handle, GWL_EXSTYLE, extendedStyle | WS_EX_TOOLWINDOW);
+            }
+
+            // We will override WndProc to listen for TaskbarCreated event
+            protected override void WndProc(ref Message m)
+            {
+                if (m.Msg == (int)RegisterWindowMessage("TaskbarCreated"))
+                {
+                    try
+                    {
+                        string appPath = Process.GetCurrentProcess().MainModule?.FileName;
+                        Process.Start(appPath); // Start a new instance of RetroBar
+                        Environment.Exit(0); // Exit the current instance of RetroBar
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"Error restarting RetroBar: {ex.Message}");
+                    }
+                }
+
+                // Call the base class to process other messages so we dont accidentally cause crashes or bugs.
+                base.WndProc(ref m);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_explorerMonitor != null){_explorerMonitor?.Dispose();}
+        }
+    }
+}

--- a/RetroBar/Utilities/WindowManager.cs
+++ b/RetroBar/Utilities/WindowManager.cs
@@ -18,7 +18,7 @@ namespace RetroBar.Utilities
         private readonly ShellManager _shellManager;
         private readonly Updater _updater;
 
-        private readonly ExplorerMonitor _explorerMonitor = new ExplorerMonitor();
+        private readonly ExplorerMonitor _explorerMonitor = new();
 
         public WindowManager(ShellManager shellManager, StartMenuMonitor startMenuMonitor, Updater updater)
         {
@@ -187,7 +187,7 @@ namespace RetroBar.Utilities
 
         public void Dispose()
         {
-            if (_explorerMonitor != null){_explorerMonitor?.Dispose();}
+            _explorerMonitor?.Dispose();
             _shellManager.ExplorerHelper.HideExplorerTaskbar = false;
             Settings.Instance.PropertyChanged -= Settings_PropertyChanged;
         }

--- a/RetroBar/Utilities/WindowManager.cs
+++ b/RetroBar/Utilities/WindowManager.cs
@@ -1,11 +1,11 @@
 using ManagedShell;
 using ManagedShell.AppBar;
 using ManagedShell.Common.Logging;
+using ManagedShell.Interop;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Windows.Forms;
 using Microsoft.Win32;
@@ -27,8 +27,6 @@ namespace RetroBar.Utilities
         private volatile bool _ExplorerMonitorIsMonitoring;
         private Thread _ExplorerMonitorThread;
         private int _ExplorerMonitorLastExplorerPid = -1;
-        [DllImport("user32.dll")] private static extern IntPtr GetShellWindow();
-        [DllImport("user32.dll")] private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
 
         public WindowManager(ShellManager shellManager, StartMenuMonitor startMenuMonitor, Updater updater)
         {
@@ -372,7 +370,7 @@ namespace RetroBar.Utilities
             // This is a call that is available on Windows 10 and 11.
             // It will return the exact explorer process that is hosting the desktop shell,
             // this ensures we dont accidentally target something like "File Explorer".
-            IntPtr shellWindowHandle = GetShellWindow();
+            IntPtr shellWindowHandle = NativeMethods.GetShellWindow();
 
             if (shellWindowHandle == IntPtr.Zero)
             {
@@ -380,7 +378,7 @@ namespace RetroBar.Utilities
                 return 0;
             }
 
-            GetWindowThreadProcessId(shellWindowHandle, out uint shellProcessId);
+            NativeMethods.GetWindowThreadProcessId(shellWindowHandle, out uint shellProcessId);
             return shellProcessId;
         }
 

--- a/RetroBar/Utilities/WindowManager.cs
+++ b/RetroBar/Utilities/WindowManager.cs
@@ -26,7 +26,7 @@ namespace RetroBar.Utilities
             _startMenuMonitor = startMenuMonitor;
             _updater = updater;
 
-            _explorerMonitor.ExplorerMonitorStart();
+            _explorerMonitor.ExplorerMonitorStart(this);
 
             _shellManager.ExplorerHelper.HideExplorerTaskbar = true;
 

--- a/RetroBar/Utilities/WindowManager.cs
+++ b/RetroBar/Utilities/WindowManager.cs
@@ -23,6 +23,8 @@ namespace RetroBar.Utilities
         private volatile bool _ExplorerMonitorIsMonitoring;
         private ExplorerMonitor _ExplorerMonitor;
         [DllImport("user32.dll", SetLastError = true)] private static extern uint RegisterWindowMessage(string lpString);
+        [DllImport("user32.dll")] private static extern IntPtr SetWindowLong(IntPtr hwnd, int index, int newStyle);
+        [DllImport("user32.dll")] private static extern int GetWindowLong(IntPtr hwnd, int index);
 
         public WindowManager(ShellManager shellManager, StartMenuMonitor startMenuMonitor, Updater updater)
         {
@@ -218,6 +220,9 @@ namespace RetroBar.Utilities
         public class ExplorerMonitor : Form
         {
             private readonly WindowManager _windowManager;
+            private const int GWL_EXSTYLE = -20;
+            private const int WS_EX_TOOLWINDOW = 0x00000080;
+            private const int WS_EX_APPWINDOW = 0x00040000;
 
             public ExplorerMonitor(WindowManager windowManager)
             {
@@ -233,6 +238,10 @@ namespace RetroBar.Utilities
                 Visible = false; // Set the form as invisible
                 StartPosition = FormStartPosition.Manual; // Dont center this form
                 Location = new System.Drawing.Point(-1000, -1000); // Move it far off-screen
+
+                // Remove ExplorerMonitor from the Alt+Tab list by modifying its extended style
+                var extendedStyle = GetWindowLong(this.Handle, GWL_EXSTYLE);
+                SetWindowLong(this.Handle, GWL_EXSTYLE, extendedStyle | WS_EX_TOOLWINDOW);
             }
 
             // We will override WndProc to listen for TaskbarCreated event


### PR DESCRIPTION
**Description:**
Implement Explorer.exe monitoring feature using TaskbarCreated event.

**What it does?**
If we detect that Explorer.exe has restarted we will call ReopenTaskbars.


**Why?**
This will ensure that when Explorer is restarted, RetroBar is also re-initialized.
This will fix stuff like wrong desktop size etc that would happen if we did not re-initialize RetroBar.


**Tests performed:**
Lots and lots of testing, on Windows 11 systems.


**What issues this should fix?**
@dremin PR https://github.com/cairoshell/ManagedShell/pull/113 fixed all of these:
https://github.com/dremin/RetroBar/issues/942
https://github.com/dremin/RetroBar/issues/938
https://github.com/dremin/RetroBar/issues/927
https://github.com/dremin/RetroBar/issues/648
https://github.com/dremin/RetroBar/issues/476
https://github.com/dremin/RetroBar/issues/457
so this PR is just a follow up now, this will fix some bugs like the desktop is not resized properly after Explorer is restarted etc.