### PR TITLE
Hold shift to perform opposite middle mouse action

### DIFF
--- a/RetroBar/Controls/TaskButton.xaml.cs
+++ b/RetroBar/Controls/TaskButton.xaml.cs
@@ -182,7 +182,8 @@ namespace RetroBar.Controls
                 {
                     return;
                 }
-                if (Settings.Instance.TaskMiddleClickAction == TaskMiddleClickOption.CloseTask)
+                if (Settings.Instance.TaskMiddleClickAction == TaskMiddleClickOption.CloseTask !=
+                    (Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift)))
                 {
                     Window?.Close();
                 }


### PR DESCRIPTION
If the middle mouse action is configured to close the task, holding shift while pressing it will instead open a new instance.

If the middle mouse action is configured to open a new instance, holding shift while pressing it will instead close the task.