### PR TITLE
Add clock click action settings

### DIFF
--- a/RetroBar/Languages/English.xaml
+++ b/RetroBar/Languages/English.xaml
@@ -57,6 +57,13 @@
         <s:String>Open a new instance</s:String>
         <s:String>Close the task</s:String>
     </x:Array>
+    <s:String x:Key="clock_click_action">_Clock click action:</s:String>
+    <x:Array x:Key="clock_click_action_values" Type="s:String">
+        <s:String>Do nothing</s:String>
+        <s:String>Open Aero clock flyout</s:String>
+        <s:String>Open Action Center/Notification Center</s:String>
+        <s:String>Open Modern calendar</s:String>
+    </x:Array>
     <s:String x:Key="version">Version {0}</s:String>
     <s:String x:Key="visit_on_github">Visit RetroBar on GitHub</s:String>
     <s:String x:Key="taskbar_scale">Taskbar scale</s:String>

--- a/RetroBar/PropertiesWindow.xaml
+++ b/RetroBar/PropertiesWindow.xaml
@@ -364,6 +364,16 @@
                         </DockPanel>
                         <DockPanel>
                             <Label VerticalAlignment="Center"
+                                   Target="{Binding ElementName=cboClockAction}">
+                                <AccessText Text="{DynamicResource clock_click_action}" />
+                            </Label>
+                            <ComboBox x:Name="cboClockAction"
+                                      ItemsSource="{DynamicResource clock_click_action_values}"
+                                      SelectedIndex="{Binding Source={x:Static Settings:Settings.Instance}, Path=ClockClickAction, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource enumConverter}}"
+                                      SelectionChanged="cboClockAction_SelectionChanged" />
+                        </DockPanel>
+                        <DockPanel>
+                            <Label VerticalAlignment="Center"
                                    Target="{Binding ElementName=cboInvertIconsMode}">
                                 <AccessText Text="{DynamicResource invert_system_icons}" />
                             </Label>

--- a/RetroBar/PropertiesWindow.xaml.cs
+++ b/RetroBar/PropertiesWindow.xaml.cs
@@ -277,6 +277,30 @@ namespace RetroBar
         private void cboLanguageSelect_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
         {
             LoadVersion();
+
+            if (!EnvironmentHelper.IsWindows10OrBetter)
+            {
+                PopulateClockActionsForPreWindows10();
+            }
+        }
+
+        private void PopulateClockActionsForPreWindows10()
+        {
+            var availableClockActions = (FindResource("clock_click_action_values") as Array)?.Cast<object>().ToList();
+            if (availableClockActions == null)
+            {
+                return;
+            }
+
+            if (Settings.Instance.ClockClickAction > ClockClickOption.OpenAeroClockFlyout)
+            {
+                // ClockClickAction is out of range; reverting to default
+                cboClockAction.SelectedValue = availableClockActions[(int)ClockClickOption.OpenAeroClockFlyout];
+            }
+
+            availableClockActions.RemoveAt(availableClockActions.Count - 1);
+            availableClockActions.RemoveAt(availableClockActions.Count - 1);
+            cboClockAction.ItemsSource = availableClockActions;
         }
 
         private void cboEdgeSelect_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
@@ -308,6 +332,14 @@ namespace RetroBar
             if (cboMiddleMouseAction.SelectedItem == null)
             {
                 cboMiddleMouseAction.SelectedValue = cboMiddleMouseAction.Items[(int)Settings.Instance.TaskMiddleClickAction];
+            }
+        }
+
+        private void cboClockAction_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            if (cboClockAction.SelectedItem == null)
+            {
+                cboClockAction.SelectedValue = cboClockAction.Items[(int)Settings.Instance.ClockClickAction];
             }
         }
 

--- a/RetroBar/Utilities/ClockFlyoutLauncher.cs
+++ b/RetroBar/Utilities/ClockFlyoutLauncher.cs
@@ -1,0 +1,147 @@
+﻿using ManagedShell.AppBar;
+using ManagedShell.Common.Helpers;
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Windows;
+using static ManagedShell.Interop.NativeMethods;
+using Rect = ManagedShell.Interop.NativeMethods.Rect;
+using Screen = System.Windows.Forms.Screen;
+
+namespace RetroBar.Utilities
+{
+    internal class ClockFlyoutLauncher
+    {
+        private const SetWindowPosFlags NoPosFlags = SetWindowPosFlags.SWP_NOSIZE | SetWindowPosFlags.SWP_NOACTIVATE | SetWindowPosFlags.SWP_NOZORDER;
+
+        #region Aero clock
+
+        private static readonly Lazy<Type> AeroClockType = new(() => Type.GetTypeFromCLSID(new("A323554A-0FE1-4E49-AEE1-6722465D799F")));
+        private static object _aeroClockInstance;
+
+        [ComImport, Guid("7A5FCA8A-76B1-44C8-A97C-E7173CCA5F4F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IAeroClock // For 8+
+        {
+            [PreserveSig]
+            void ShowFlyout(IntPtr hWnd, ref Rect lpRect);
+        }
+
+        [ComImport, Guid("4376DF10-A662-420B-B30D-958881461EF9"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IAeroClockLegacy // For Vista and 7
+        {
+            [PreserveSig]
+            void ShowFlyout(int unk, ref Rect lpRect);
+        }
+
+        internal static void ShowAeroClockFlyout(IntPtr taskbarHwnd)
+        {
+            Screen taskbarScreen = Screen.FromHandle(taskbarHwnd);
+            if (!GetWindowRect(taskbarHwnd, out Rect lpRect))
+            {
+                return;
+            }
+
+            _aeroClockInstance ??= Activator.CreateInstance(AeroClockType.Value);
+
+            if (ManagedShell.Common.Helpers.EnvironmentHelper.IsWindows8OrBetter)
+            {
+                ((IAeroClock)_aeroClockInstance).ShowFlyout(taskbarHwnd, ref lpRect);
+            }
+            else
+            {
+                ((IAeroClockLegacy)_aeroClockInstance).ShowFlyout(0, ref lpRect);
+            }
+
+            FixAeroClockFlyoutPosition(taskbarScreen);
+        }
+
+        private static void FixAeroClockFlyoutPosition(Screen taskbarScreen)
+        {
+            IntPtr clockFlyoutHwnd = FindWindow("ClockFlyoutWindow", null);
+            if (clockFlyoutHwnd == IntPtr.Zero)
+            {
+                return;
+            }
+
+            GetWindowRect(clockFlyoutHwnd, out Rect clockFlyoutRect);
+
+            // Keep the flyout at least 3 by 3 pixels inside the working area
+            int newX = (int)Math.Max(taskbarScreen.WorkingArea.Left + 3, Math.Min(taskbarScreen.WorkingArea.Right - (clockFlyoutRect.Width) - 3, clockFlyoutRect.Left));
+            int newY = (int)Math.Max(taskbarScreen.WorkingArea.Top + 3, Math.Min(taskbarScreen.WorkingArea.Bottom - (clockFlyoutRect.Height) - 3, clockFlyoutRect.Top));
+            SetWindowPos(clockFlyoutHwnd, IntPtr.Zero, newX, newY, 0, 0, (int)(NoPosFlags));
+        }
+
+        #endregion Aero clock
+
+        #region Modern clock
+
+        internal static void ShowClockFlyout()
+        {
+            // Current implementation is for the primary screen only
+            Screen screen = Screen.PrimaryScreen;
+            FlowDirection flowDirection = Application.Current.FindResource("flow_direction") as FlowDirection? ?? FlowDirection.LeftToRight;
+
+            PostMessage(WindowHelper.FindWindowsTray(WindowHelper.FindWindowsTray(IntPtr.Zero)), (uint)0x5CE, IntPtr.Zero, IntPtr.Zero);
+
+            // Launching the Modern clock is slower than the Aero clock, so we need to wait for the window to be created...
+            System.Windows.Threading.DispatcherTimer timer = new()
+            {
+                Interval = TimeSpan.FromTicks(10)
+            };
+
+            int attempts = 0;
+            StringBuilder className = new(256);
+
+            timer.Tick += (_, _) =>
+            {
+                if (++attempts > 100)
+                {
+                    timer.Stop();
+                    return;
+                }
+
+                IntPtr hwnd = GetForegroundWindow();
+                if (hwnd == IntPtr.Zero)
+                {
+                    return;
+                }
+
+                className.Clear();
+                _ = GetClassName(hwnd, className, className.Capacity);
+                if (className.ToString() != "Windows.UI.Core.CoreWindow")
+                {
+                    return;
+                }
+
+                ShowWindow(hwnd, (int)WindowShowStyle.Hide);
+
+                if (!GetWindowRect(hwnd, out Rect rect) || rect.Width <= 1)
+                {
+                    return;
+                }
+
+                timer.Stop();
+
+                // Move to corner where the taskbar is
+                int newX = Settings.Instance.Edge switch
+                {
+                    AppBarEdge.Left => screen.WorkingArea.Left,
+                    AppBarEdge.Right => screen.WorkingArea.Right - rect.Width,
+                    _ => (flowDirection == FlowDirection.LeftToRight) ? screen.WorkingArea.Right - rect.Width : screen.WorkingArea.Left
+                };
+
+                int newY = Settings.Instance.Edge switch
+                {
+                    AppBarEdge.Top => screen.WorkingArea.Top,
+                    _ => screen.WorkingArea.Bottom - rect.Height
+                };
+
+                SetWindowPos(hwnd, IntPtr.Zero, newX, newY, 0, 0, (int)(NoPosFlags | SetWindowPosFlags.SWP_SHOWWINDOW));
+            };
+
+            timer.Start();
+        }
+    }
+
+    #endregion Modern clock
+}

--- a/RetroBar/Utilities/Settings.cs
+++ b/RetroBar/Utilities/Settings.cs
@@ -304,6 +304,13 @@ namespace RetroBar.Utilities
             set => SetEnum(ref _taskMiddleClickAction, value);
         }
 
+        private ClockClickOption _clockClickAction = EnvironmentHelper.IsWindows10OrBetter ? ClockClickOption.OpenActionCenter : ClockClickOption.OpenAeroClockFlyout;
+        public ClockClickOption ClockClickAction
+        {
+            get => _clockClickAction;
+            set => SetEnum(ref _clockClickAction, value);
+        }
+
         private bool _checkForUpdates = true;
         public bool CheckForUpdates
         {
@@ -374,6 +381,14 @@ namespace RetroBar.Utilities
         DoNothing,
         OpenNewInstance,
         CloseTask
+    }
+
+    public enum ClockClickOption
+    {
+        DoNothing,
+        OpenAeroClockFlyout,
+        OpenActionCenter,
+        OpenModernCalendar,
     }
 
     public enum NotifyIconBehavior


### PR DESCRIPTION
### Clock Functionality Enhancements:

* Removed the `singleClick` `DispatcherTimer` and its associated methods from `Clock.xaml.cs`, simplifying the clock's event handling (otherwise, delayed response for single clicking). [[1]](diffhunk://#diff-36728b171fad7eef549bbfc75d4ddec512c9987736688bd1b6d967d9a0634581L30) [[2]](diffhunk://#diff-36728b171fad7eef549bbfc75d4ddec512c9987736688bd1b6d967d9a0634581L41-L43) [[3]](diffhunk://#diff-36728b171fad7eef549bbfc75d4ddec512c9987736688bd1b6d967d9a0634581L99-L114)
* Added support for various clock click actions (e.g., opening the modern calendar, Aero clock flyout, Action Center for Windows 10/Notification Center for Windows 11) by updating the `Clock_OnMouseLeftButtonDown` method in `Clock.xaml.cs`.
* Introduced a new `ClockFlyoutLauncher` class to handle the display of different clock flyouts, including Aero and modern clock flyouts.

### UI and Settings Adjustments:

* Updated `English.xaml` to include new string resources for clock click actions and their values.
* Modified `PropertiesWindow.xaml` to add a new combo box for selecting clock click actions in the settings UI.
* Updated `Settings.cs` to include a new `ClockClickOption` enum and a corresponding property to store the user's clock click action preference. [[1]](diffhunk://#diff-34f2e18b6c2eb59b9081b836e88989a951068f13262ad8cd0a58a579422660b9R307-R313) [[2]](diffhunk://#diff-34f2e18b6c2eb59b9081b836e88989a951068f13262ad8cd0a58a579422660b9R386-R393)

### Compatibility Improvements:

* Added logic in `PropertiesWindow.xaml.cs` to list only available clock click actions for pre-Windows 10 systems, ensuring compatibility with previous versions of Windows (7, 8, 8.1). [[1]](diffhunk://#diff-ee9d6c6349f26aaf8056271c266ee24a00c8dd4c353f1ec42a77dcd823eb815aR280-R303) [[2]](diffhunk://#diff-ee9d6c6349f26aaf8056271c266ee24a00c8dd4c353f1ec42a77dcd823eb815aR338-R345)