### PR TITLE
Allow Start button on all taskbars

### DIFF
--- a/RetroBar/Controls/StartButton.xaml.cs
+++ b/RetroBar/Controls/StartButton.xaml.cs
@@ -171,8 +171,13 @@ namespace RetroBar.Controls
             hideFloatingStart();
         }
 
-        private void AppVisibilityHelper_StartMenuVisibilityChanged(object? sender, ManagedShell.Common.SupportingClasses.LauncherVisibilityEventArgs e)
+        private void AppVisibilityHelper_StartMenuVisibilityChanged(object? sender, StartMenuMonitor.StartMenuMonitorEventArgs e)
         {
+            if (e.Visible && e.TaskbarHwndActivated != IntPtr.Zero && Host != null && e.TaskbarHwndActivated != Host.Handle)
+            {
+                // Only set as visible when activated from our taskbar
+                return;
+            }
             SetStartMenuState(e.Visible);
         }
 

--- a/RetroBar/Controls/StartButton.xaml.cs
+++ b/RetroBar/Controls/StartButton.xaml.cs
@@ -79,11 +79,7 @@ namespace RetroBar.Controls
             }
 
             SetStartMenuState(false);
-            if (Host != null && StartMenuMonitor != null && Settings.Instance.ShowMultiMon)
-            {
-                StartMenuMonitor.HideStartMenu(Host.Handle);
             }
-        }
 
         private void OpenStartMenu()
         {

--- a/RetroBar/Controls/StartButton.xaml.cs
+++ b/RetroBar/Controls/StartButton.xaml.cs
@@ -87,7 +87,7 @@ namespace RetroBar.Controls
             Host?.SetTrayHost();
             Host?.SetStartMenuOpen(true);
             pendingOpenTimer.Start();
-            if (Host != null && StartMenuMonitor != null)
+            if (Host != null && StartMenuMonitor != null && Settings.Instance.ShowMultiMon && Settings.Instance.ShowStartButtonMultiMon)
             {
                 StartMenuMonitor.ShowStartMenu(Host.Handle);
             }

--- a/RetroBar/Controls/StartButton.xaml.cs
+++ b/RetroBar/Controls/StartButton.xaml.cs
@@ -79,6 +79,10 @@ namespace RetroBar.Controls
             }
 
             SetStartMenuState(false);
+            if (Host != null && StartMenuMonitor != null && Settings.Instance.ShowMultiMon)
+            {
+                StartMenuMonitor.HideStartMenu(Host.Handle);
+            }
         }
 
         private void OpenStartMenu()
@@ -86,7 +90,14 @@ namespace RetroBar.Controls
             Host?.SetTrayHost();
             Host?.SetStartMenuOpen(true);
             pendingOpenTimer.Start();
-            ShellHelper.ShowStartMenu();
+            if (Host != null && StartMenuMonitor != null && Settings.Instance.ShowMultiMon)
+            {
+                StartMenuMonitor.ShowStartMenu(Host.Handle);
+            }
+            else
+            {
+                ShellHelper.ShowStartMenu();
+            }
         }
 
         #region Drag

--- a/RetroBar/Languages/English.xaml
+++ b/RetroBar/Languages/English.xaml
@@ -29,6 +29,7 @@
     <s:String x:Key="show_input_language">Show the input _language</s:String>
     <s:String x:Key="show_clock">Show the cloc_k</s:String>
     <s:String x:Key="show_multi_mon">Show on _multiple displays</s:String>
+    <s:String x:Key="show_start_button_multi_mon">Show _Start button on all taskbars</s:String>
     <s:String x:Key="show_quick_launch">Show _Quick Launch</s:String>
     <s:String x:Key="select_location">_Select location...</s:String>
     <s:String x:Key="quick_launch_folder">Quick Launch - Choose a folder</s:String>
@@ -63,8 +64,8 @@
     <s:String x:Key="taskbar_scale_1x">100%</s:String>
     <s:String x:Key="taskbar_scale_2x">200%</s:String>
     <s:String x:Key="taskbar_scale_current">Current setting: {0}%</s:String>
-    <s:String x:Key="debug_logging">Enable debug logging</s:String>
-    <s:String x:Key="check_for_updates">Check for updates</s:String>
+    <s:String x:Key="debug_logging">Enable _debug logging</s:String>
+    <s:String x:Key="check_for_updates">Check for u_pdates</s:String>
     <s:String x:Key="ok_dialog">OK</s:String>
 
     <s:String x:Key="customize_notifications">Customize Notifications</s:String>

--- a/RetroBar/PropertiesWindow.xaml
+++ b/RetroBar/PropertiesWindow.xaml
@@ -383,6 +383,11 @@
                                       IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowMultiMon, UpdateSourceTrigger=PropertyChanged}">
                                 <Label Content="{DynamicResource show_multi_mon}" />
                             </CheckBox>
+                            <CheckBox x:Name="cbShowStartButtonMultiMon"
+                                      IsEnabled="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowMultiMon, UpdateSourceTrigger=PropertyChanged}"
+                                      IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowStartButtonMultiMon, UpdateSourceTrigger=PropertyChanged}">
+                                <Label Content="{DynamicResource show_start_button_multi_mon}" />
+                            </CheckBox>
                             <DockPanel>
                                 <Label VerticalAlignment="Center"
                                        Target="{Binding ElementName=cboMultiMonMode}">

--- a/RetroBar/PropertiesWindow.xaml.cs
+++ b/RetroBar/PropertiesWindow.xaml.cs
@@ -78,6 +78,7 @@ namespace RetroBar
             LoadPreviewHeight();
             LoadAutoStart();
             LoadLanguages();
+            LoadOSSupport();
             LoadRows();
             LoadThemes();
             LoadVersion();
@@ -162,6 +163,14 @@ namespace RetroBar
             foreach (var language in _dictionaryManager.GetLanguages())
             {
                 cboLanguageSelect.Items.Add(language);
+            }
+        }
+
+        private void LoadOSSupport()
+        {
+            if (!EnvironmentHelper.IsWindows10OrBetter)
+            {
+                cbShowStartButtonMultiMon.Visibility = Visibility.Collapsed;
             }
         }
 

--- a/RetroBar/RetroBar.csproj
+++ b/RetroBar/RetroBar.csproj
@@ -42,7 +42,7 @@
 
   <ItemGroup>
     <PackageReference Include="gong-wpf-dragdrop" Version="3.1.1" />
-    <PackageReference Include="ManagedShell" Version="0.0.270" />
+    <PackageReference Include="ManagedShell" Version="0.0.275" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.2" />
   </ItemGroup>
 

--- a/RetroBar/Taskbar.xaml.cs
+++ b/RetroBar/Taskbar.xaml.cs
@@ -89,11 +89,7 @@ namespace RetroBar
                 ShowDesktopButtonTray.Visibility = Visibility.Visible;
             }
 
-            // Hide the start button on secondary display(s)
-            if (!Screen.Primary)
-            {
-                StartButton.Visibility = Visibility.Collapsed;
-            }
+            UpdateStartButton();
 
             AutoHideElement = TaskbarContentControl;
 
@@ -153,6 +149,17 @@ namespace RetroBar
             {
                 SetTrayHost();
             }
+        }
+
+        private void UpdateStartButton()
+        {
+            if (!Screen.Primary && !Settings.Instance.ShowStartButtonMultiMon)
+            {
+                StartButton.Visibility = Visibility.Collapsed;
+                return;
+            }
+
+            StartButton.Visibility = Visibility.Visible;
         }
 
         private void RecalculateSize(bool performResize = true)
@@ -282,6 +289,10 @@ namespace RetroBar
             {
                 PeekDuringAutoHide();
                 RecalculateSize();
+            }
+            else if (e.PropertyName == nameof(Settings.ShowStartButtonMultiMon))
+            {
+                UpdateStartButton();
             }
         }
 

--- a/RetroBar/Utilities/Settings.cs
+++ b/RetroBar/Utilities/Settings.cs
@@ -310,6 +310,13 @@ namespace RetroBar.Utilities
             get => _checkForUpdates;
             set => Set(ref _checkForUpdates, value);
         }
+
+        private bool _showStartButtonMultiMon = false;
+        public bool ShowStartButtonMultiMon
+        {
+            get => _showStartButtonMultiMon;
+            set => Set(ref _showStartButtonMultiMon, value);
+        }
         #endregion
 
         #region Old Properties

--- a/RetroBar/Utilities/StartMenuMonitor.cs
+++ b/RetroBar/Utilities/StartMenuMonitor.cs
@@ -1,13 +1,14 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 using System.Windows.Threading;
 using ManagedShell.Common.Helpers;
 using ManagedShell.Common.Logging;
 using ManagedShell.Common.SupportingClasses;
-using ManagedShell.Interop;
+using static ManagedShell.Interop.NativeMethods;
 
 namespace RetroBar.Utilities
 {
-    public class StartMenuMonitor: IDisposable
+    public class StartMenuMonitor : IDisposable
     {
         private AppVisibilityHelper _appVisibilityHelper;
         private DispatcherTimer _poller;
@@ -97,19 +98,221 @@ namespace RetroBar.Utilities
 
         private bool isVisibleByClass(string className)
         {
-            IntPtr hStartMenu = NativeMethods.FindWindowEx(IntPtr.Zero, IntPtr.Zero, className, IntPtr.Zero);
+            IntPtr hStartMenu = FindWindowEx(IntPtr.Zero, IntPtr.Zero, className, IntPtr.Zero);
 
             if (hStartMenu == IntPtr.Zero)
             {
                 return false;
             }
 
-            return NativeMethods.IsWindowVisible(hStartMenu);
+            return IsWindowVisible(hStartMenu);
+        }
+
+        private IImmersiveLauncher GetImmersiveLauncher(IntPtr taskbarHwnd)
+        {
+            var shell = (IServiceProvider)new CImmersiveShell();
+
+            if (shell.QueryService(ref CLSID_MonitorManager, ref IID_MonitorManager, out object monitorManagerObj) != 0)
+            {
+                ShellLogger.Warning("StartMenuMonitor: Failed to query for IImmersiveMonitorManager");
+                return null;
+            }
+            IImmersiveMonitorManager monitorManager = (IImmersiveMonitorManager)monitorManagerObj;
+
+            if (shell.QueryService(ref CLSID_ImmersiveLauncher, ref IID_ImmersiveLauncher, out object immersiveLauncherObj) != 0)
+            {
+                ShellLogger.Warning("StartMenuMonitor: Failed to query for IImmersiveLauncher");
+                return null;
+            }
+            IImmersiveLauncher immersiveLauncher = (IImmersiveLauncher)immersiveLauncherObj;
+
+            if (monitorManager.GetFromHandle(MonitorFromWindow(taskbarHwnd, MONITOR_DEFAULTTONEAREST), out IImmersiveMonitor monitor) != 0)
+            {
+                ShellLogger.Warning("StartMenuMonitor: Failed to get monitor from taskbar window handle");
+                return null;
+            }
+
+            if (immersiveLauncher.ConnectToMonitor(monitor) != 0)
+            {
+                ShellLogger.Warning("StartMenuMonitor: Failed to connect IImmersiveLauncher to monitor");
+                return null;
+            }
+
+            return immersiveLauncher;
+        }
+
+        internal void ShowStartMenu(IntPtr taskbarHwnd)
+        {
+            if (!EnvironmentHelper.IsWindows10RS4OrBetter || 
+                FindWindowEx(IntPtr.Zero, IntPtr.Zero, "OpenShell.COwnerWindow", IntPtr.Zero) != IntPtr.Zero)
+            {
+                // Always use the Windows key when IImmersiveLauncher is unavailable
+                // Also use the Windows key when Open Shell Menu is running, because we cannot otherwise invoke it
+                ShellHelper.ShowStartMenu();
+                return;
+            }
+
+            try
+            {
+                IImmersiveLauncher immersiveLauncher = GetImmersiveLauncher(taskbarHwnd);
+                if (immersiveLauncher != null && 
+                    immersiveLauncher.ShowStartView(IMMERSIVELAUNCHERSHOWMETHOD.ILSM_STARTBUTTON, IMMERSIVELAUNCHERSHOWFLAGS.ILSF_IGNORE_SET_FOREGROUND_ERROR) == 0)
+                {
+                    return;
+                }
+                ShellLogger.Warning("StartMenuMonitor: Failed to show Start menu via IImmersiveLauncher");
+            }
+            catch (Exception e)
+            {
+                ShellLogger.Warning($"StartMenuMonitor: Failed to show Start menu via IImmersiveLauncher: {e}");
+            }
+
+            ShellHelper.ShowStartMenu();
+        }
+
+        internal void HideStartMenu(IntPtr taskbarHwnd)
+        {
+            if (!EnvironmentHelper.IsWindows10RS4OrBetter || !isModernStartMenuOpen())
+            {
+                return;
+            }
+
+            IImmersiveLauncher immersiveLauncher = GetImmersiveLauncher(taskbarHwnd);
+            if (immersiveLauncher != null)
+            {
+                immersiveLauncher.Dismiss(IMMERSIVELAUNCHERDISMISSMETHOD.ILDM_STARTTIP);
+            }
         }
 
         public void Dispose()
         {
             _poller?.Stop();
         }
+
+        #region Immersive launcher interfaces
+
+        // Managed interface definitions c/o https://github.com/MishaProductions/CustomShell/
+
+        enum IMMERSIVE_MONITOR_FILTER_FLAGS
+        {
+            IMMERSIVE_MONITOR_FILTER_FLAGS_NONE = 0x0,
+            IMMERSIVE_MONITOR_FILTER_FLAGS_DISABLE_TRAY = 0x1,
+        }
+
+        [ComImport]
+        [Guid("880b26f8-9197-43d0-8045-8702d0d72000")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        interface IImmersiveMonitor
+        {
+            public int GetIdentity(out uint pIdentity);
+            public int Append(object unknown);
+            public int GetHandle(nint phMonitor);
+            public int IsConnected(out bool pfConnected);
+            public int IsPrimary(out bool pfPrimary);
+            public int GetTrustLevel(out uint level);
+            public int GetDisplayRect(out Rect prcDisplayRect);
+            public int GetOrientation(out uint pdwOrientation);
+            public int GetWorkArea(out Rect prcWorkArea);
+            public int IsEqual(IImmersiveMonitor pMonitor, out bool pfEqual);
+            public int GetTrustLevel2(out uint level);
+            public int GetEffectiveDpi(out uint dpiX, out uint dpiY);
+            public int GetFilterFlags(out IMMERSIVE_MONITOR_FILTER_FLAGS flags);
+        }
+
+        enum IMMERSIVE_MONITOR_MOVE_DIRECTION
+        {
+            IMMD_PREVIOUS = 0,
+            IMMD_NEXT = 1
+        }
+
+        [ComImport]
+        [Guid("4d4c1e64-e410-4faa-bafa-59ca069bfec2")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        interface IImmersiveMonitorManager
+        {
+            public int GetCount(out uint pcMonitors);
+            public int GetConnectedCount(out uint pcMonitors);
+            public int GetAt(out uint idxMonitor, out IImmersiveMonitor monitor);
+            public int GetFromHandle(nint monitor, out IImmersiveMonitor monitor2);
+            public int GetFromIdentity(uint identity, out IImmersiveMonitor monitor);
+            public int GetImmersiveProxyMonitor(out IImmersiveMonitor monitor);
+            public int QueryService(nint monit, ref Guid guidService, ref Guid riid, [MarshalAs(UnmanagedType.IUnknown)] out object service);
+            public int QueryServiceByIdentity(uint monit, ref Guid guidService, ref Guid riid, [MarshalAs(UnmanagedType.IUnknown)] out object service);
+            public int QueryServiceFromWindow(nint hwnd, ref Guid guidService, ref Guid riid, [MarshalAs(UnmanagedType.IUnknown)] out object service);
+            public int QueryServiceFromPoint(nint point, ref Guid guidService, ref Guid riid, [MarshalAs(UnmanagedType.IUnknown)] out object service);
+            public int GetNextImmersiveMonitor(IMMERSIVE_MONITOR_MOVE_DIRECTION direction, IImmersiveMonitor monitor, out IImmersiveMonitor monitorout);
+            public int GetMonitorArray(out object array);
+            public int SetFilter(object filter);
+        }
+
+        enum IMMERSIVELAUNCHERSHOWMETHOD
+        {
+            ILSM_INVALID = 0x0,
+            ILSM_HSHELLTASKMAN = 0x1,
+            ILSM_IMMERSIVEBACKGROUND = 0x4,
+            ILSM_APPCLOSED = 0x6,
+            ILSM_STARTBUTTON = 0xB,
+            ILSM_RETAILDEMO_EDUCATIONAPP = 0xC,
+            ILSM_BACK = 0xD,
+            ILSM_SESSIONONUNLOCK = 0xE
+        }
+
+        enum IMMERSIVELAUNCHERSHOWFLAGS
+        {
+            ILSF_NONE = 0x0,
+            ILSF_IGNORE_SET_FOREGROUND_ERROR = 0x4,
+        }
+
+        enum IMMERSIVELAUNCHERDISMISSMETHOD
+        {
+            ILDM_INVALID = 0x0,
+            ILDM_HSHELLTASKMAN = 0x1,
+            ILDM_STARTCHARM = 0x2,
+            ILDM_BACKGESTURE = 0x3,
+            ILDM_ESCAPEKEY = 0x4,
+            ILDM_SHOWDESKTOP = 0x5,
+            ILDM_STARTTIP = 0x6,
+            ILDM_GENERIC_NONANIMATING = 0x7,
+        }
+
+        [ComImport]
+        [Guid("d8d60399-a0f1-f987-5551-321fd1b49864")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        interface IImmersiveLauncher
+        {
+            public int ShowStartView(IMMERSIVELAUNCHERSHOWMETHOD showMethod, IMMERSIVELAUNCHERSHOWFLAGS showFlags);
+            public int Dismiss(IMMERSIVELAUNCHERDISMISSMETHOD dismissMethod);
+            public int Dismiss2(IMMERSIVELAUNCHERDISMISSMETHOD dismissMethod);
+            public int DismissSynchronouslyWithoutTransition();
+            public int IsVisible(out bool p0);
+            public int OnStartButtonPressed(IMMERSIVELAUNCHERSHOWMETHOD showMethod, IMMERSIVELAUNCHERDISMISSMETHOD dismissMethod);
+            public int SetForeground();
+            public int ConnectToMonitor(IImmersiveMonitor monitor);
+            public int GetMonitor(out IImmersiveMonitor monitor);
+            public int OnFirstSignAnimationFinished();
+            public int Prelaunch();
+        }
+
+        static Guid CLSID_MonitorManager = new Guid("47094e3a-0cf2-430f-806f-cf9e4f0f12dd");
+        static Guid IID_MonitorManager = new Guid("4d4c1e64-e410-4faa-bafa-59ca069bfec2");
+        static Guid CLSID_ImmersiveLauncher = new Guid("6f86e01c-c649-4d61-be23-f1322ddeca9d");
+        static Guid IID_ImmersiveLauncher = new Guid("d8d60399-a0f1-f987-5551-321fd1b49864");
+
+        [ComImport]
+        [Guid("6d5140c1-7436-11ce-8034-00aa006009fa")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        interface IServiceProvider
+        {
+            int QueryService(ref Guid guidService, ref Guid riid,
+                       [MarshalAs(UnmanagedType.Interface)] out object ppvObject);
+        }
+
+        [ComImport]
+        [Guid("c2f03a33-21f5-47fa-b4bb-156362a2f239")]
+        [ClassInterface(ClassInterfaceType.None)]
+        class CImmersiveShell
+        {
+        }
+        #endregion
     }
 }

--- a/RetroBar/Utilities/StartMenuMonitor.cs
+++ b/RetroBar/Utilities/StartMenuMonitor.cs
@@ -183,10 +183,11 @@ namespace RetroBar.Utilities
             _taskbarHwndActivated = taskbarHwnd;
 
             if (!EnvironmentHelper.IsWindows10OrBetter ||
-                FindWindowEx(IntPtr.Zero, IntPtr.Zero, "OpenShell.COwnerWindow", IntPtr.Zero) != IntPtr.Zero)
+                FindWindowEx(IntPtr.Zero, IntPtr.Zero, "OpenShell.COwnerWindow", IntPtr.Zero) != IntPtr.Zero ||
+                FindWindowEx(IntPtr.Zero, IntPtr.Zero, "DV2ControlHost", IntPtr.Zero) != IntPtr.Zero)
             {
                 // Always use the Windows key when IImmersiveLauncher or IImmersiveMonitor is unavailable
-                // Also use the Windows key when Open Shell Menu is running, because we cannot otherwise invoke it
+                // Also use the Windows key when Open Shell Menu or StartIsBack is running, because we cannot otherwise invoke it
                 ShellHelper.ShowStartMenu();
                 return;
             }

--- a/RetroBar/Utilities/StartMenuMonitor.cs
+++ b/RetroBar/Utilities/StartMenuMonitor.cs
@@ -143,7 +143,7 @@ namespace RetroBar.Utilities
 
         internal void ShowStartMenu(IntPtr taskbarHwnd)
         {
-            if (!EnvironmentHelper.IsWindows10RS4OrBetter || 
+            if (!EnvironmentHelper.IsWindows10RS1OrBetter || 
                 FindWindowEx(IntPtr.Zero, IntPtr.Zero, "OpenShell.COwnerWindow", IntPtr.Zero) != IntPtr.Zero)
             {
                 // Always use the Windows key when IImmersiveLauncher is unavailable
@@ -172,7 +172,7 @@ namespace RetroBar.Utilities
 
         internal void HideStartMenu(IntPtr taskbarHwnd)
         {
-            if (!EnvironmentHelper.IsWindows10RS4OrBetter || !isModernStartMenuOpen())
+            if (!EnvironmentHelper.IsWindows10RS1OrBetter || !isModernStartMenuOpen())
             {
                 return;
             }

--- a/RetroBar/Utilities/StartMenuMonitor.cs
+++ b/RetroBar/Utilities/StartMenuMonitor.cs
@@ -122,7 +122,7 @@ namespace RetroBar.Utilities
 
         private IImmersiveMonitor GetImmersiveMonitor(IServiceProvider shell, IntPtr hWnd)
         {
-            if (shell.QueryService(ref CLSID_MonitorManager, ref IID_MonitorManager, out object monitorManagerObj) != 0)
+            if (shell.QueryService(ref CLSID_ImmersiveMonitorManager, ref IID_ImmersiveMonitorManager, out object monitorManagerObj) != 0)
             {
                 ShellLogger.Warning("StartMenuMonitor: Failed to query for IImmersiveMonitorManager");
                 return null;
@@ -193,6 +193,10 @@ namespace RetroBar.Utilities
 
             try
             {
+                // Allow Explorer to steal focus
+                GetWindowThreadProcessId(FindWindowEx(IntPtr.Zero, IntPtr.Zero, "Progman", "Program Manager"), out uint procId);
+                AllowSetForegroundWindow(procId);
+
                 if (EnvironmentHelper.IsWindows10RS1OrBetter)
                 {
                     IImmersiveLauncher_Win10RS1 immersiveLauncher = GetImmersiveLauncher_Win10RS1(taskbarHwnd);
@@ -268,7 +272,7 @@ namespace RetroBar.Utilities
         {
             public int GetIdentity(out uint pIdentity);
             public int Append(object unknown);
-            public int GetHandle(nint phMonitor);
+            public int GetHandle(out nint phMonitor);
             public int IsConnected(out bool pfConnected);
             public int IsPrimary(out bool pfPrimary);
             public int GetTrustLevel(out uint level);
@@ -294,7 +298,7 @@ namespace RetroBar.Utilities
         {
             public int GetCount(out uint pcMonitors);
             public int GetConnectedCount(out uint pcMonitors);
-            public int GetAt(out uint idxMonitor, out IImmersiveMonitor monitor);
+            public int GetAt(uint idxMonitor, out IImmersiveMonitor monitor);
             public int GetFromHandle(nint monitor, out IImmersiveMonitor monitor2);
             public int GetFromIdentity(uint identity, out IImmersiveMonitor monitor);
             public int GetImmersiveProxyMonitor(out IImmersiveMonitor monitor);
@@ -379,8 +383,8 @@ namespace RetroBar.Utilities
             public int GetMonitor(out IImmersiveMonitor monitor);
         }
 
-        static Guid CLSID_MonitorManager = new Guid("47094e3a-0cf2-430f-806f-cf9e4f0f12dd");
-        static Guid IID_MonitorManager = new Guid("4d4c1e64-e410-4faa-bafa-59ca069bfec2");
+        static Guid CLSID_ImmersiveMonitorManager = new Guid("47094e3a-0cf2-430f-806f-cf9e4f0f12dd");
+        static Guid IID_ImmersiveMonitorManager = new Guid("4d4c1e64-e410-4faa-bafa-59ca069bfec2");
         static Guid CLSID_ImmersiveLauncher = new Guid("6f86e01c-c649-4d61-be23-f1322ddeca9d");
         static Guid IID_ImmersiveLauncher_Win10RS1 = new Guid("d8d60399-a0f1-f987-5551-321fd1b49864");
         static Guid IID_ImmersiveLauncher_Win81 = new Guid("93f91f5a-a4ca-4205-9beb-ce4d17c708f9");

--- a/RetroBar/Utilities/StartMenuMonitor.cs
+++ b/RetroBar/Utilities/StartMenuMonitor.cs
@@ -225,31 +225,6 @@ namespace RetroBar.Utilities
             ShellHelper.ShowStartMenu();
         }
 
-        internal void HideStartMenu(IntPtr taskbarHwnd)
-        {
-            if (!EnvironmentHelper.IsWindows10OrBetter || !isModernStartMenuOpen())
-            {
-                return;
-            }
-
-            if (EnvironmentHelper.IsWindows10RS1OrBetter)
-            {
-                IImmersiveLauncher_Win10RS1 immersiveLauncher = GetImmersiveLauncher_Win10RS1(taskbarHwnd);
-                if (immersiveLauncher != null)
-                {
-                    immersiveLauncher.Dismiss(IMMERSIVELAUNCHERDISMISSMETHOD.ILDM_STARTTIP);
-                }
-            }
-            else
-            {
-                IImmersiveLauncher_Win81 immersiveLauncher = GetImmersiveLauncher_Win81(taskbarHwnd);
-                if (immersiveLauncher != null)
-                {
-                    immersiveLauncher.Dismiss(IMMERSIVELAUNCHERDISMISSMETHOD.ILDM_STARTTIP);
-                }
-            }
-        }
-
         public void Dispose()
         {
             _poller?.Stop();


### PR DESCRIPTION
Fixes #158

- Use IImmersiveLauncher on Windows 10 and newer to open the Start menu on the correct display
- Fall back to WinKey-based activation when OpenShellMenu/SIB is running, and when the option is disabled
  - OpenShellMenu has no cross-process programmatic way to open the menu on a specific monitor
- Setting appears only when running Windows 10 and newer, but is respected if set manually
- Only the clicked Start button will be pressed