### PR TITLE
Use dynamic menu items

### DIFF
--- a/RetroBar/PropertiesWindow.xaml
+++ b/RetroBar/PropertiesWindow.xaml
@@ -181,7 +181,7 @@
                                     <AccessText Text="{DynamicResource language_text}"
                                                 ToolTip="{DynamicResource language_tip}" />
                                 </Label>
-                                <ComboBox Name="cboLanguageSelect"
+                                <ComboBox x:Name="cboLanguageSelect"
                                           SelectedValue="{Binding Source={x:Static Settings:Settings.Instance}, Path=Language, UpdateSourceTrigger=PropertyChanged}" />
                             </DockPanel>
                             <DockPanel>
@@ -190,7 +190,7 @@
                                     <AccessText Text="{DynamicResource theme_text}"
                                                 ToolTip="{DynamicResource theme_tip}" />
                                 </Label>
-                                <ComboBox Name="cboThemeSelect"
+                                <ComboBox x:Name="cboThemeSelect"
                                           SelectedValue="{Binding Source={x:Static Settings:Settings.Instance}, Path=Theme, UpdateSourceTrigger=PropertyChanged}" />
                             </DockPanel>
                             <DockPanel>
@@ -199,10 +199,10 @@
                                     <AccessText Text="{DynamicResource location_text}"
                                                 ToolTip="{DynamicResource location_tip}" />
                                 </Label>
-                                <ComboBox Name="cboEdgeSelect"
+                                <ComboBox x:Name="cboEdgeSelect"
                                           ItemsSource="{DynamicResource location_values}"
                                           SelectedIndex="{Binding Source={x:Static Settings:Settings.Instance}, Path=Edge, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource enumConverter}}"
-                                          SelectionChanged="cboEdgeSelect_SelectionChanged" />
+                                          SelectionChanged="CboEdgeSelect_SelectionChanged" />
                             </DockPanel>
                             <DockPanel Visibility="{Binding Source={x:Static Settings:Settings.Instance}, Path=Edge, Converter={StaticResource edgeOrientationVisibilityConverter}, ConverterParameter='horizontal'}">
                                 <Label VerticalAlignment="Center"
@@ -212,14 +212,14 @@
                                 </Label>
                                 <ComboBox x:Name="cboRowCount"
                                           SelectedIndex="{Binding Source={x:Static Settings:Settings.Instance}, Path=RowCount, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource countToIndexConverter}}"
-                                          SelectionChanged="cboRowCount_SelectionChanged" />
+                                          SelectionChanged="CboRowCount_SelectionChanged" />
                             </DockPanel>
                             <DockPanel Visibility="{Binding Source={x:Static Settings:Settings.Instance}, Path=Edge, Converter={StaticResource edgeOrientationVisibilityConverter}, ConverterParameter='vertical'}">
                                 <Label VerticalAlignment="Center"
                                        Target="{Binding ElementName=sldTaskbarWidth}">
                                     <AccessText Text="{DynamicResource taskbar_width}" />
                                 </Label>
-                                <Slider Name="sldTaskbarWidth"
+                                <Slider x:Name="sldTaskbarWidth"
                                         Orientation="Horizontal"
                                         IsSnapToTickEnabled="True"
                                         Value="{Binding Source={x:Static Settings:Settings.Instance}, Path=TaskbarWidth, UpdateSourceTrigger=PropertyChanged}"
@@ -277,7 +277,7 @@
                                                   DockPanel.Dock="Right">
                                             <StackPanel Orientation="Horizontal">
                                                 <StackPanel Orientation="Horizontal">
-                                                    <ToggleButton Name="NotifyIconToggleButton"
+                                                    <ToggleButton x:Name="NotifyIconToggleButton"
                                                                   Focusable="False"
                                                                   Visibility="{Binding Source={x:Static Settings:Settings.Instance}, Path=CollapseNotifyIcons, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource boolToVisibilityConverter}}"
                                                                   Style="{DynamicResource TrayToggleButton}"/>
@@ -334,9 +334,9 @@
                             Margin="10">
                     <StackPanel Orientation="Vertical"
                                 Margin="0,0,0,10">
-                        <CheckBox Checked="AutoStartCheckBox_OnChecked"
-                                  Unchecked="AutoStartCheckBox_OnChecked"
-                                  Name="AutoStartCheckBox">
+                        <CheckBox x:Name="cbAutoStart"
+                                  Checked="CbAutoStart_OnChecked"
+                                  Unchecked="CbAutoStart_OnChecked">
                             <Label Content="{DynamicResource autostart}" />
                         </CheckBox>
                         <CheckBox x:Name="cbUseSoftwareRendering"
@@ -363,7 +363,7 @@
                             <ComboBox x:Name="cboMiddleMouseAction"
                                       ItemsSource="{DynamicResource middle_mouse_task_action_values}"
                                       SelectedIndex="{Binding Source={x:Static Settings:Settings.Instance}, Path=TaskMiddleClickAction, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource enumConverter}}"
-                                      SelectionChanged="cboMiddleMouseAction_SelectionChanged" />
+                                      SelectionChanged="CboMiddleMouseAction_SelectionChanged" />
                         </DockPanel>
                         <DockPanel>
                             <Label VerticalAlignment="Center"
@@ -373,21 +373,21 @@
                             <ComboBox x:Name="cboClockAction"
                                       ItemsSource="{DynamicResource clock_click_action_values}"
                                       SelectedIndex="{Binding Source={x:Static Settings:Settings.Instance}, Path=ClockClickAction, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource enumConverter}}"
-                                      SelectionChanged="cboClockAction_SelectionChanged" />
+                                      SelectionChanged="CboClockAction_SelectionChanged" />
                         </DockPanel>
                         <DockPanel>
                             <Label VerticalAlignment="Center"
                                    Target="{Binding ElementName=cboInvertIconsMode}">
                                 <AccessText Text="{DynamicResource invert_system_icons}" />
                             </Label>
-                            <ComboBox Name="cboInvertIconsMode"
+                            <ComboBox x:Name="cboInvertIconsMode"
                                       ItemsSource="{DynamicResource invert_system_icons_values}"
                                       SelectedIndex="{Binding Source={x:Static Settings:Settings.Instance}, Path=InvertIconsMode, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource enumConverter}}"
-                                      SelectionChanged="cboInvertIconsMode_SelectionChanged" />
+                                      SelectionChanged="CboInvertIconsMode_SelectionChanged" />
                         </DockPanel>
                         <Button HorizontalAlignment="Right"
-                                        Content="{DynamicResource customize}"
-                                        Click="CustomizeNotifications_OnClick" />
+                                Content="{DynamicResource customize}"
+                                Click="CustomizeNotifications_OnClick" />
                     </StackPanel>
                     <GroupBox Header="{DynamicResource multiple_displays}"
                               Margin="0,0,0,10">
@@ -406,11 +406,11 @@
                                        Target="{Binding ElementName=cboMultiMonMode}">
                                     <AccessText Text="{DynamicResource show_tasks_on}" />
                                 </Label>
-                                <ComboBox Name="cboMultiMonMode"
+                                <ComboBox x:Name="cboMultiMonMode"
                                           IsEnabled="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowMultiMon, UpdateSourceTrigger=PropertyChanged}"
                                           ItemsSource="{DynamicResource show_tasks_on_values}"
                                           SelectedIndex="{Binding Source={x:Static Settings:Settings.Instance}, Path=MultiMonMode, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource enumConverter}}"
-                                          SelectionChanged="cboMultiMonMode_SelectionChanged" />
+                                          SelectionChanged="CboMultiMonMode_SelectionChanged" />
                             </DockPanel>
                         </StackPanel>
                     </GroupBox>
@@ -419,7 +419,7 @@
                             <DockPanel Margin="20,0">
                                 <Label DockPanel.Dock="Left" Content="{DynamicResource taskbar_scale_1x}" />
                                 <Label DockPanel.Dock="Right" Content="{DynamicResource taskbar_scale_2x}" />
-                                <Slider Name="sldTaskbarScale"
+                                <Slider x:Name="sldTaskbarScale"
                                         Orientation="Horizontal"
                                         IsSnapToTickEnabled="True"
                                         Value="{Binding Source={x:Static Settings:Settings.Instance}, Path=TaskbarScale, UpdateSourceTrigger=PropertyChanged}"
@@ -428,7 +428,7 @@
                                         TickFrequency="0.05"
                                         TickPlacement="BottomRight" />
                             </DockPanel>
-                            <TextBlock Name="txtCurrentScale"
+                            <TextBlock x:Name="txtCurrentScale"
                                        HorizontalAlignment="Center">
                                 <TextBlock.Text>
                                     <MultiBinding Converter="{StaticResource doubleToPercentConverter}" UpdateSourceTrigger="PropertyChanged">
@@ -440,7 +440,7 @@
                         </StackPanel>
                     </GroupBox>
                     <DockPanel Margin="0,10,0,0">
-                        <TextBlock Name="txtVersion"
+                        <TextBlock x:Name="txtVersion"
                                    DockPanel.Dock="Left"
                                    Margin="0,0,10,0" />
                         <TextBlock DockPanel.Dock="Right"

--- a/RetroBar/PropertiesWindow.xaml.cs
+++ b/RetroBar/PropertiesWindow.xaml.cs
@@ -150,11 +150,11 @@ namespace RetroBar
                 {
                     if (rKeyValueNames.Contains("RetroBar"))
                     {
-                        AutoStartCheckBox.IsChecked = true;
+                        cbAutoStart.IsChecked = true;
                     }
                     else
                     {
-                        AutoStartCheckBox.IsChecked = false;
+                        cbAutoStart.IsChecked = false;
                     }
                 }
             }
@@ -267,7 +267,7 @@ namespace RetroBar
             UpdateWindowPosition();
         }
 
-        private void AutoStartCheckBox_OnChecked(object sender, RoutedEventArgs e)
+        private void CbAutoStart_OnChecked(object sender, RoutedEventArgs e)
         {
             try
             {
@@ -308,7 +308,7 @@ namespace RetroBar
             cboClockAction.ItemsSource = availableClockActions;
         }
 
-        private void cboEdgeSelect_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        private void CboEdgeSelect_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
         {
             if (cboEdgeSelect.SelectedItem == null)
             {
@@ -316,7 +316,7 @@ namespace RetroBar
             }
         }
 
-        private void cboMultiMonMode_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        private void CboMultiMonMode_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
         {
             if (cboMultiMonMode.SelectedItem == null)
             {
@@ -324,7 +324,7 @@ namespace RetroBar
             }
         }
 
-        private void cboInvertIconsMode_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        private void CboInvertIconsMode_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
         {
             if (cboInvertIconsMode.SelectedItem == null)
             {
@@ -332,7 +332,7 @@ namespace RetroBar
             }
         }
 
-        private void cboMiddleMouseAction_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        private void CboMiddleMouseAction_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
         {
             if (cboMiddleMouseAction.SelectedItem == null)
             {
@@ -340,7 +340,7 @@ namespace RetroBar
             }
         }
 
-        private void cboClockAction_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        private void CboClockAction_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
         {
             if (cboClockAction.SelectedItem == null)
             {
@@ -348,7 +348,7 @@ namespace RetroBar
             }
         }
 
-        private void cboRowCount_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        private void CboRowCount_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
         {
             if (cboRowCount.SelectedItem == null)
             {

--- a/RetroBar/Taskbar.xaml
+++ b/RetroBar/Taskbar.xaml
@@ -20,18 +20,18 @@
             <converters:SettingsToTextFormattingModeConverter x:Key="textFormattingModeConverter" />
             <converters:EdgeOrientationConverter x:Key="edgeOrientationConverter" />
             <converters:DockOrientationConverter x:Key="dockOrientationConverter" />
-
-            <Style TargetType="ContextMenu"
-                   x:Key="{x:Type ContextMenu}"
-                   BasedOn="{StaticResource GlobalFonts}">
-                <Setter Property="TextOptions.TextRenderingMode">
-                    <Setter.Value>
-                        <Binding Source="{x:Static utilities:Settings.Instance}"
-                                 Path="AllowFontSmoothing"
-                                 Converter="{StaticResource textRenderingModeConverter}" />
-                    </Setter.Value>
-                </Setter>
-            </Style>
+            <converters:BoolToVisibilityConverter x:Key="boolToVisibilityConverter" />
+            <MenuItem x:Shared="false" x:Key="ToolbarsItem" Header="{DynamicResource toolbars}">
+                <MenuItem Header="{DynamicResource quick_launch}" IsCheckable="true" IsChecked="{Binding Source={x:Static utilities:Settings.Instance}, Path=ShowQuickLaunch, UpdateSourceTrigger=PropertyChanged}" />
+                <Separator />
+                <MenuItem Header="{DynamicResource new_toolbar}" x:Name="NewToolbarMenuItem" />
+            </MenuItem>
+            <MenuItem x:Shared="false" x:Key="SetTimeMenuItem" Header="{DynamicResource set_time}" Click="SetTimeMenuItem_OnClick" />
+            <MenuItem x:Shared="false" x:Key="CustomizeNotificationsMenuItem" Header="{DynamicResource customize_notifications_menu}" Click="CustomizeNotificationsMenuItem_OnClick" />
+            <MenuItem x:Shared="false" x:Key="TaskManagerMenuItem" Style="{DynamicResource TaskManMenuItem}" Click="TaskManagerMenuItem_OnClick" />
+            <MenuItem x:Shared="false" x:Key="LockTaskbarMenuItem" Header="{DynamicResource lock_taskbar_menu}" IsCheckable="True" IsChecked="{Binding Source={x:Static utilities:Settings.Instance}, Path=LockTaskbar, UpdateSourceTrigger=PropertyChanged}" />
+            <MenuItem x:Shared="false" x:Key="PropertiesMenuItem" Header="{DynamicResource tray_properties}" Click="PropertiesMenuItem_OnClick" />
+            <MenuItem x:Shared="false" x:Key="ExitMenuItem" Header="{DynamicResource exit_retrobar}" Click="ExitMenuItem_OnClick" Visibility="{Binding Source={x:Static utilities:Settings.Instance}, Path=ShowExitMenuItem, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource boolToVisibilityConverter}}" />
         </ResourceDictionary>
     </Window.Resources>
     <TextOptions.TextFormattingMode>
@@ -84,8 +84,21 @@
                              RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=Window}" />
                 </DockPanel.Dock>
             </controls:ShowDesktopButton>
-            <GroupBox Style="{DynamicResource Tray}"
-                      PreviewMouseRightButtonUp="NotifyArea_PreviewMouseRightButtonUp">
+            <GroupBox Style="{DynamicResource Tray}">
+                <GroupBox.ContextMenu>
+                    <ContextMenu>
+                        <!--StaticResourceExtension ResourceKey="ToolbarsItem" />
+                        <Separator /-->
+                        <StaticResourceExtension ResourceKey="SetTimeMenuItem" />
+                        <StaticResourceExtension ResourceKey="CustomizeNotificationsMenuItem" />
+                        <Separator />
+                        <StaticResourceExtension ResourceKey="TaskManagerMenuItem" />
+                        <Separator />
+                        <StaticResourceExtension ResourceKey="LockTaskbarMenuItem" />
+                        <StaticResourceExtension ResourceKey="PropertiesMenuItem" />
+                        <StaticResourceExtension ResourceKey="ExitMenuItem" />
+                    </ContextMenu>
+                </GroupBox.ContextMenu>
                 <DockPanel.Dock>
                     <Binding Converter="{StaticResource dockOrientationConverter}"
                              ConverterParameter="trailing"
@@ -99,8 +112,7 @@
                                  RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=Window}" />
                     </StackPanel.Orientation>
                     <controls:NotifyIconList NotificationArea="{Binding NotificationArea}" />
-                    <controls:Clock VerticalAlignment="Center"
-                                    PreviewMouseRightButtonUp="Clock_PreviewMouseRightButtonUp" />
+                    <controls:Clock VerticalAlignment="Center" />
                 </StackPanel>
             </GroupBox>
             <controls:InputLanguage VerticalAlignment="Stretch"
@@ -120,42 +132,18 @@
     <appbar:AppBarWindow.ContextMenu>
         <ContextMenu Opened="ContextMenu_Opened">
             <!-- TODO: Add when desk bands and additional taskbars are supported. -->
-            <!-- MenuItem Header="{DynamicResource toolbars}">
-                <MenuItem Header="{DynamicResource quick_launch}" IsCheckable="true"
-                          IsChecked="{Binding Source={x:Static utilities:Settings.Instance}, Path=ShowQuickLaunch, UpdateSourceTrigger=PropertyChanged}" />
-                <Separator />
-                <MenuItem Header="{DynamicResource new_toolbar}" Name="NewToolbarMenuItem" />
-            </MenuItem>
+            <!--StaticResourceExtension ResourceKey="ToolbarsItem" />
             <Separator /-->
-            <MenuItem Header="{DynamicResource set_time}"
-                      Name="DateTimeMenuItem"
-                      Click="DateTimeMenuItem_OnClick"
-                      FontWeight="Bold"
-                      Visibility="Collapsed" />
-            <MenuItem Header="{DynamicResource customize_notifications_menu}"
-                      Name="CustomizeNotificationsMenuItem"
-                      Click="CustomizeNotificationsMenuItem_OnClick" Visibility="Collapsed" />
-            <Separator Name="NotificationAreaSeparator"
-                       Visibility="Collapsed" />
-            <MenuItem Style="{DynamicResource TaskManMenuItem}"
-                      Name="TaskManagerMenuItem"
-                      Click="TaskManagerMenuItem_OnClick" />
+            <StaticResourceExtension ResourceKey="TaskManagerMenuItem" />
             <Separator />
-            <MenuItem Header="{DynamicResource update_available}"
-                      Name="UpdateAvailableMenuItem"
+            <MenuItem x:Name="UpdateAvailableMenuItem"
+                      Header="{DynamicResource update_available}"
                       Click="UpdateAvailableMenuItem_OnClick"
                       FontWeight="Bold"
                       Visibility="Collapsed" />
-            <MenuItem Header="{DynamicResource lock_taskbar_menu}"
-                      Name="LockTaskbarMenuItem"
-                      IsCheckable="True"
-                      IsChecked="{Binding Source={x:Static utilities:Settings.Instance}, Path=LockTaskbar, UpdateSourceTrigger=PropertyChanged}"/>
-            <MenuItem Header="{DynamicResource tray_properties}"
-                      Name="PropertiesMenuItem"
-                      Click="PropertiesMenuItem_OnClick" />
-            <MenuItem Header="{DynamicResource exit_retrobar}"
-                      Name="ExitMenuItem"
-                      Click="ExitMenuItem_OnClick" />
+            <StaticResourceExtension ResourceKey="LockTaskbarMenuItem" />
+            <StaticResourceExtension ResourceKey="PropertiesMenuItem" />
+            <StaticResourceExtension ResourceKey="ExitMenuItem" />
         </ContextMenu>
     </appbar:AppBarWindow.ContextMenu>
 </appbar:AppBarWindow>

--- a/RetroBar/Taskbar.xaml.cs
+++ b/RetroBar/Taskbar.xaml.cs
@@ -9,7 +9,6 @@ using System.Windows;
 using System.Windows.Controls;
 using RetroBar.Utilities;
 using Application = System.Windows.Application;
-using RetroBar.Controls;
 using System.Diagnostics;
 using System.Windows.Input;
 using ManagedShell.Common.Logging;
@@ -47,8 +46,6 @@ namespace RetroBar
             set => Settings.Instance.RowCount = value;
         }
 
-        private bool _clockRightClicked;
-        private bool _notifyAreaRightClicked;
         private bool _startMenuOpen;
         private LowLevelMouseHook _mouseDragHook;
         private Point? _mouseDragStart = null;
@@ -318,7 +315,7 @@ namespace RetroBar
             }
         }
 
-        private void DateTimeMenuItem_OnClick(object sender, RoutedEventArgs e)
+        private void SetTimeMenuItem_OnClick(object sender, RoutedEventArgs e)
         {
             ShellHelper.StartProcess("timedate.cpl");
         }
@@ -418,47 +415,6 @@ namespace RetroBar
             {
                 UpdateAvailableMenuItem.Visibility = Visibility.Visible;
             }
-
-            // Some menu items should only be accessible when the clock is what was right-clicked
-
-            if (_clockRightClicked)
-            {
-                DateTimeMenuItem.Visibility = Visibility.Visible;
-            }
-            else
-            {
-                DateTimeMenuItem.Visibility = Visibility.Collapsed;
-            }
-
-            if(_notifyAreaRightClicked && Settings.Instance.CollapseNotifyIcons)
-            {
-                CustomizeNotificationsMenuItem.Visibility = Visibility.Visible;
-            }
-            else
-            {
-                CustomizeNotificationsMenuItem.Visibility = Visibility.Collapsed;
-            }
-
-            if (_clockRightClicked || (_notifyAreaRightClicked && Settings.Instance.CollapseNotifyIcons))
-            {
-                NotificationAreaSeparator.Visibility = Visibility.Visible;
-            }
-            else
-            {
-                NotificationAreaSeparator.Visibility = Visibility.Collapsed;
-            }
-
-            if (Settings.Instance.ShowExitMenuItem)
-            {
-                ExitMenuItem.Visibility = Visibility.Visible;
-            }
-            else
-            {
-                ExitMenuItem.Visibility = Visibility.Collapsed;
-            }
-
-            _clockRightClicked = false;
-            _notifyAreaRightClicked = false;
         }
 
         public void SetTrayHost()
@@ -485,16 +441,6 @@ namespace RetroBar
             {
                 OnPropertyChanged(nameof(AllowAutoHide));
             }
-        }
-
-        private void Clock_PreviewMouseRightButtonUp(object sender, MouseButtonEventArgs e)
-        {
-            _clockRightClicked = true;
-        }
-
-        private void NotifyArea_PreviewMouseRightButtonUp(object sender, MouseButtonEventArgs e)
-        {
-            _notifyAreaRightClicked = true;
         }
 
         private void Taskbar_OnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
Some XAML refactoring and updating of method names to "fix naming rule", updating of control names and event handler methods. This is a working, merge-ready part of #461, otherwise it will never get merged!

* Updated control names in `RetroBar/PropertiesWindow.xaml` to use `x:Name` instead of `Name` for consistency. [[1]](diffhunk://#diff-e421c4818ef731884c912b0af4b71fcb3397f5ede2dd1069ad60b4489d15fddbL184-R184) [[2]](diffhunk://#diff-e421c4818ef731884c912b0af4b71fcb3397f5ede2dd1069ad60b4489d15fddbL193-R193) [[3]](diffhunk://#diff-e421c4818ef731884c912b0af4b71fcb3397f5ede2dd1069ad60b4489d15fddbL202-R205) [[4]](diffhunk://#diff-e421c4818ef731884c912b0af4b71fcb3397f5ede2dd1069ad60b4489d15fddbL215-R222) [[5]](diffhunk://#diff-e421c4818ef731884c912b0af4b71fcb3397f5ede2dd1069ad60b4489d15fddbL280-R280) [[6]](diffhunk://#diff-e421c4818ef731884c912b0af4b71fcb3397f5ede2dd1069ad60b4489d15fddbL337-R339) [[7]](diffhunk://#diff-e421c4818ef731884c912b0af4b71fcb3397f5ede2dd1069ad60b4489d15fddbL366-R366) [[8]](diffhunk://#diff-e421c4818ef731884c912b0af4b71fcb3397f5ede2dd1069ad60b4489d15fddbL376-R386) [[9]](diffhunk://#diff-e421c4818ef731884c912b0af4b71fcb3397f5ede2dd1069ad60b4489d15fddbL409-R413) [[10]](diffhunk://#diff-e421c4818ef731884c912b0af4b71fcb3397f5ede2dd1069ad60b4489d15fddbL422-R422) [[11]](diffhunk://#diff-e421c4818ef731884c912b0af4b71fcb3397f5ede2dd1069ad60b4489d15fddbL431-R431) [[12]](diffhunk://#diff-e421c4818ef731884c912b0af4b71fcb3397f5ede2dd1069ad60b4489d15fddbL443-R443)
* Renamed `AutoStartCheckBox` control to `cbAutoStart` for consistency.
* Renamed event handler methods in `RetroBar/PropertiesWindow.xaml.cs` to follow a consistent naming convention. [[1]](diffhunk://#diff-ee9d6c6349f26aaf8056271c266ee24a00c8dd4c353f1ec42a77dcd823eb815aL153-R157) [[2]](diffhunk://#diff-ee9d6c6349f26aaf8056271c266ee24a00c8dd4c353f1ec42a77dcd823eb815aL270-R270) [[3]](diffhunk://#diff-ee9d6c6349f26aaf8056271c266ee24a00c8dd4c353f1ec42a77dcd823eb815aL311-R351)
* Added new `MenuItem` resources and updated the context menu in `RetroBar/Taskbar.xaml` to use them as needed. [[1]](diffhunk://#diff-fd0c4c874b083d364a952d32278741b2ca1d463256f6c1a4649bba72ae16ed8fL23-R34) [[2]](diffhunk://#diff-fd0c4c874b083d364a952d32278741b2ca1d463256f6c1a4649bba72ae16ed8fL87-R101) [[3]](diffhunk://#diff-fd0c4c874b083d364a952d32278741b2ca1d463256f6c1a4649bba72ae16ed8fL102-R115)

This seems even closer to the XP behavior. Once the template is abstracted/detached/unhardcoded from the taskbar, it should also allow the use of custom menu items for the theme (so the user can customize items to hide or show them, apart from the Exit option in Properties).