### PR TITLE
Fix taskbar dragging when a clock action is selected

### DIFF
--- a/RetroBar/Controls/Clock.xaml.cs
+++ b/RetroBar/Controls/Clock.xaml.cs
@@ -162,6 +162,13 @@ namespace RetroBar.Controls
 
         private void Clock_OnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
+            if (Settings.Instance.ClockClickAction == ClockClickOption.DoNothing)
+            {
+                return;
+            }
+
+            e.Handled = true;
+
             switch (Settings.Instance.ClockClickAction)
             {
                 case ClockClickOption.OpenModernCalendar:


### PR DESCRIPTION
(otherwise, do nothing, and allow dragging from that part of the taskbar)