### PR TITLE
Move the Open Shell menu

### DIFF
--- a/RetroBar/Utilities/StartMenuMonitor.cs
+++ b/RetroBar/Utilities/StartMenuMonitor.cs
@@ -188,7 +188,7 @@ namespace RetroBar.Utilities
                 return;
             }
 
-            SetWindowPos(hStartMenu, IntPtr.Zero, x, y, 0, 0, (int)(SetWindowPosFlags.SWP_NOSIZE | SetWindowPosFlags.SWP_NOZORDER | SetWindowPosFlags.SWP_FRAMECHANGED));
+            SetWindowPos(hStartMenu, IntPtr.Zero, x, y, 0, 0, (int)(SetWindowPosFlags.SWP_NOSIZE | SetWindowPosFlags.SWP_NOZORDER));
         }
 
         private IImmersiveMonitor GetImmersiveMonitor(ManagedShell.UWPInterop.Interfaces.IServiceProvider shell, IntPtr hWnd)

--- a/RetroBar/Utilities/StartMenuMonitor.cs
+++ b/RetroBar/Utilities/StartMenuMonitor.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using System.Windows;
 using System.Windows.Threading;
+using ManagedShell.AppBar;
 using ManagedShell.Common.Helpers;
 using ManagedShell.Common.Logging;
 using ManagedShell.Common.SupportingClasses;
@@ -58,6 +60,7 @@ namespace RetroBar.Utilities
             {
                 // Open Shell Menu
                 newIsVisible = true;
+                relocateStartMenuByClass("OpenShell.CMenuContainer");
             }
 
             setVisibility(newIsVisible);
@@ -179,6 +182,102 @@ namespace RetroBar.Utilities
             return immersiveLauncher;
         }
 
+        private void relocateStartMenuByClass(string className)
+        {
+            if (_taskbarHwndActivated == IntPtr.Zero)
+            {
+                return;
+            }
+
+            // Get current window rects
+            IntPtr hStartMenu = FindWindowEx(IntPtr.Zero, IntPtr.Zero, className, IntPtr.Zero);
+            if (hStartMenu == IntPtr.Zero)
+            {
+                return;
+            }
+            FlowDirection flowDirection = Application.Current.FindResource("flow_direction") as FlowDirection? ?? FlowDirection.LeftToRight;
+            GetWindowRect(hStartMenu, out ManagedShell.Interop.NativeMethods.Rect startMenuRect);
+            GetWindowRect(_taskbarHwndActivated, out ManagedShell.Interop.NativeMethods.Rect taskbarRect);
+
+            // Check if the start menu is mis-positioned
+            bool needsReposition = false;
+            switch (Settings.Instance.Edge)
+            {
+                case AppBarEdge.Left:
+                    // Top right of taskbar is menu top left
+                    needsReposition = !(taskbarRect.Top == startMenuRect.Top && taskbarRect.Right == startMenuRect.Left);
+                    break;
+                case AppBarEdge.Right:
+                    // Top left of taskbar is menu top right
+                    needsReposition = !(taskbarRect.Top == startMenuRect.Top && taskbarRect.Left == startMenuRect.Right);
+                    break;
+                case AppBarEdge.Top:
+                    // Bottom left of taskbar is menu top left
+                    if (flowDirection == FlowDirection.LeftToRight)
+                    {
+                        needsReposition = !(taskbarRect.Bottom == startMenuRect.Top && taskbarRect.Left == startMenuRect.Left);
+                    }
+                    else
+                    {
+                        needsReposition = !(taskbarRect.Bottom == startMenuRect.Top && taskbarRect.Right == startMenuRect.Right);
+                    }
+                    break;
+                case AppBarEdge.Bottom:
+                    // Top left of taskbar is menu bottom left
+                    if (flowDirection == FlowDirection.LeftToRight)
+                    {
+                        needsReposition = !(taskbarRect.Top == startMenuRect.Bottom && taskbarRect.Left == startMenuRect.Left);
+                    }
+                    else
+                    {
+                        needsReposition = !(taskbarRect.Top == startMenuRect.Bottom && taskbarRect.Right == startMenuRect.Right);
+                    }
+                    break;
+            }
+
+            if (!needsReposition)
+            {
+                return;
+            }
+
+            int x = 0, y = 0;
+            switch (Settings.Instance.Edge)
+            {
+                case AppBarEdge.Left:
+                    x = taskbarRect.Right;
+                    y = taskbarRect.Top;
+                    break;
+                case AppBarEdge.Right:
+                    x = taskbarRect.Left - startMenuRect.Width;
+                    y = taskbarRect.Top;
+                    break;
+                case AppBarEdge.Top:
+                    if (flowDirection == FlowDirection.LeftToRight)
+                    {
+                        x = taskbarRect.Left;
+                    }
+                    else
+                    {
+                        x = taskbarRect.Right - startMenuRect.Width;
+                    }
+                    y = taskbarRect.Bottom;
+                    break;
+                case AppBarEdge.Bottom:
+                    if (flowDirection == FlowDirection.LeftToRight)
+                    {
+                        x = taskbarRect.Left;
+                    }
+                    else
+                    {
+                        x = taskbarRect.Right - startMenuRect.Width;
+                    }
+                    y = taskbarRect.Top - startMenuRect.Height;
+                    break;
+            }
+
+            SetWindowPos(hStartMenu, IntPtr.Zero, x, y, 0, 0, (int)(SetWindowPosFlags.SWP_NOSIZE | SetWindowPosFlags.SWP_NOZORDER | SetWindowPosFlags.SWP_FRAMECHANGED));
+        }
+
         internal void ShowStartMenu(IntPtr taskbarHwnd)
         {
             _taskbarHwndActivated = taskbarHwnd;
@@ -253,9 +352,9 @@ namespace RetroBar.Utilities
             public int IsConnected(out bool pfConnected);
             public int IsPrimary(out bool pfPrimary);
             public int GetTrustLevel(out uint level);
-            public int GetDisplayRect(out Rect prcDisplayRect);
+            public int GetDisplayRect(out ManagedShell.Interop.NativeMethods.Rect prcDisplayRect);
             public int GetOrientation(out uint pdwOrientation);
-            public int GetWorkArea(out Rect prcWorkArea);
+            public int GetWorkArea(out ManagedShell.Interop.NativeMethods.Rect prcWorkArea);
             public int IsEqual(IImmersiveMonitor pMonitor, out bool pfEqual);
             public int GetTrustLevel2(out uint level);
             public int GetEffectiveDpi(out uint dpiX, out uint dpiY);


### PR DESCRIPTION
Open Shell Menu doesn't handle WinKey invocation well on secondary monitors. This PR adds logic to move the Open Shell Menu to the correct position based on monitor and the screen edge of the taskbar, only when the start button is enabled for multiple monitors.

Open Shell Menu does have code that supports receiving programmatic activation via window message, but it doesn't use WM_COPYDATA so we cannot send the necessary struct cross-process.

@xoascf - This is similar to what you initially wrote for the modern calendar flyout. There is a brief flicker before it moves, but I think it is better than not moving it at all. What do you think?