### PR TITLE
Add transparent auto-hide option

### DIFF
--- a/RetroBar/Controls/StartButton.xaml.cs
+++ b/RetroBar/Controls/StartButton.xaml.cs
@@ -160,11 +160,21 @@ namespace RetroBar.Controls
 
             IsVisibleChanged += StartButton_IsVisibleChanged;
             LayoutUpdated += StartButton_LayoutUpdated;
+
+            if (Host != null)
+            {
+                Host.PropertyChanged += Taskbar_PropertyChanged;
+            }
         }
 
         private void UserControl_Unloaded(object sender, RoutedEventArgs e)
         {
             StartMenuMonitor.StartMenuVisibilityChanged -= AppVisibilityHelper_StartMenuVisibilityChanged;
+
+            if (Host != null)
+            {
+                Host.PropertyChanged -= Taskbar_PropertyChanged;
+            }
 
             Settings.Instance.PropertyChanged -= Settings_PropertyChanged;
 
@@ -202,6 +212,21 @@ namespace RetroBar.Controls
             else
             {
                 hideFloatingStart();
+            }
+        }
+
+        private void Taskbar_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (Host != null && e.PropertyName == "Opacity")
+            {
+                if (Host.Opacity == 1)
+                {
+                    openFloatingStart();
+                }
+                else
+                {
+                    hideFloatingStart();
+                }
             }
         }
 

--- a/RetroBar/Controls/StartButton.xaml.cs
+++ b/RetroBar/Controls/StartButton.xaml.cs
@@ -217,7 +217,7 @@ namespace RetroBar.Controls
 
         private void Taskbar_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            if (Host != null && e.PropertyName == "Opacity")
+            if (Host != null && e.PropertyName == nameof(Opacity))
             {
                 if (Host.Opacity == 1)
                 {

--- a/RetroBar/Languages/English.xaml
+++ b/RetroBar/Languages/English.xaml
@@ -65,6 +65,7 @@
         <s:String>Open Modern calendar</s:String>
         <s:String>Open Notification Center</s:String>
     </x:Array>
+    <s:String x:Key="auto_hide_transparent">Hide _taskbar edge with auto-hide</s:String>
     <s:String x:Key="version">Version {0}</s:String>
     <s:String x:Key="visit_on_github">Visit RetroBar on GitHub</s:String>
     <s:String x:Key="taskbar_scale">Taskbar scale</s:String>

--- a/RetroBar/Languages/English.xaml
+++ b/RetroBar/Languages/English.xaml
@@ -65,7 +65,7 @@
         <s:String>Open Modern calendar</s:String>
         <s:String>Open Notification Center</s:String>
     </x:Array>
-    <s:String x:Key="auto_hide_transparent">Hide _taskbar edge with auto-hide</s:String>
+    <s:String x:Key="auto_hide_transparent">Hide _taskbar line when hidden with auto-hide</s:String>
     <s:String x:Key="version">Version {0}</s:String>
     <s:String x:Key="visit_on_github">Visit RetroBar on GitHub</s:String>
     <s:String x:Key="taskbar_scale">Taskbar scale</s:String>

--- a/RetroBar/PropertiesWindow.xaml
+++ b/RetroBar/PropertiesWindow.xaml
@@ -355,6 +355,10 @@
                                   IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowExitMenuItem, UpdateSourceTrigger=PropertyChanged}">
                             <Label Content="{DynamicResource show_exit_menu_item}" />
                         </CheckBox>
+                        <CheckBox x:Name="cbAutoHideTransparent"
+                                  IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=AutoHideTransparent, UpdateSourceTrigger=PropertyChanged}">
+                            <Label Content="{DynamicResource auto_hide_transparent}" />
+                        </CheckBox>
                         <DockPanel>
                             <Label VerticalAlignment="Center"
                                    Target="{Binding ElementName=cboMiddleMouseAction}">

--- a/RetroBar/PropertiesWindow.xaml
+++ b/RetroBar/PropertiesWindow.xaml
@@ -257,7 +257,8 @@
                                 <Label Content="{DynamicResource show_window_previews}" />
                             </CheckBox>
                             <CheckBox x:Name="cbSlideTaskbarButtons"
-                                  IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=SlideTaskbarButtons, UpdateSourceTrigger=PropertyChanged}">
+                                      IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=SlideTaskbarButtons, UpdateSourceTrigger=PropertyChanged}"
+                                      Visibility="{Binding Source={x:Static Settings:Settings.Instance}, Path=Edge, Converter={StaticResource edgeOrientationVisibilityConverter}, ConverterParameter='horizontal'}">
                                 <Label Content="{DynamicResource slide_taskbar_buttons}" />
                             </CheckBox>
                         </StackPanel>
@@ -355,13 +356,13 @@
                                   IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=CheckForUpdates, UpdateSourceTrigger=PropertyChanged}">
                             <Label Content="{DynamicResource check_for_updates}" />
                         </CheckBox>
-                        <CheckBox x:Name="cbShowExitMenuItem"
-                                  IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowExitMenuItem, UpdateSourceTrigger=PropertyChanged}">
-                            <Label Content="{DynamicResource show_exit_menu_item}" />
-                        </CheckBox>
                         <CheckBox x:Name="cbAutoHideTransparent"
                                   IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=AutoHideTransparent, UpdateSourceTrigger=PropertyChanged}">
                             <Label Content="{DynamicResource auto_hide_transparent}" />
+                        </CheckBox>
+                        <CheckBox x:Name="cbShowExitMenuItem"
+                                  IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowExitMenuItem, UpdateSourceTrigger=PropertyChanged}">
+                            <Label Content="{DynamicResource show_exit_menu_item}" />
                         </CheckBox>
                         <DockPanel>
                             <Label VerticalAlignment="Center"

--- a/RetroBar/Taskbar.xaml.cs
+++ b/RetroBar/Taskbar.xaml.cs
@@ -291,6 +291,10 @@ namespace RetroBar
             {
                 UpdateStartButton();
             }
+            else if (e.PropertyName == nameof(Settings.AutoHideTransparent))
+            {
+                PeekDuringAutoHide();
+            }
         }
 
         private void Taskbar_OnLocationChanged(object sender, EventArgs e)
@@ -407,6 +411,21 @@ namespace RetroBar
 
             // Prevent focus indicators and tooltips while hidden
             ResetControlFocus();
+
+            if (!isHiding && Opacity < 1)
+            {
+                Opacity = 1;
+            }
+        }
+
+        protected override void OnAutoHideAnimationComplete(bool isHiding)
+        {
+            base.OnAutoHideAnimationComplete(isHiding);
+
+            if (isHiding && Settings.Instance.AutoHideTransparent && AllowsTransparency && AllowAutoHide)
+            {
+                Opacity = 0.01;
+            }
         }
 
         private void ContextMenu_Opened(object sender, RoutedEventArgs e)

--- a/RetroBar/Taskbar.xaml.cs
+++ b/RetroBar/Taskbar.xaml.cs
@@ -415,7 +415,7 @@ namespace RetroBar
             if (!isHiding && Opacity < 1)
             {
                 Opacity = 1;
-                OnPropertyChanged("Opacity");
+                OnPropertyChanged(nameof(Opacity));
             }
         }
 
@@ -426,7 +426,7 @@ namespace RetroBar
             if (isHiding && Settings.Instance.AutoHideTransparent && AllowsTransparency && AllowAutoHide)
             {
                 Opacity = 0.01;
-                OnPropertyChanged("Opacity");
+                OnPropertyChanged(nameof(Opacity));
             }
         }
 

--- a/RetroBar/Taskbar.xaml.cs
+++ b/RetroBar/Taskbar.xaml.cs
@@ -415,6 +415,7 @@ namespace RetroBar
             if (!isHiding && Opacity < 1)
             {
                 Opacity = 1;
+                OnPropertyChanged("Opacity");
             }
         }
 
@@ -425,6 +426,7 @@ namespace RetroBar
             if (isHiding && Settings.Instance.AutoHideTransparent && AllowsTransparency && AllowAutoHide)
             {
                 Opacity = 0.01;
+                OnPropertyChanged("Opacity");
             }
         }
 

--- a/RetroBar/Utilities/Settings.cs
+++ b/RetroBar/Utilities/Settings.cs
@@ -340,6 +340,13 @@ namespace RetroBar.Utilities
             get => _showStartButtonMultiMon;
             set => Set(ref _showStartButtonMultiMon, value);
         }
+
+        private bool _autoHideTransparent = false;
+        public bool AutoHideTransparent
+        {
+            get => _autoHideTransparent;
+            set => Set(ref _autoHideTransparent, value);
+        }
         #endregion
 
         #region Old Properties


### PR DESCRIPTION
Optionally hides the taskbar edge (and Vista floating start button) when auto-hide is active. We use 0.01 opacity so that hit testing will still work.

Fixes #769 