### PR TITLE
Fix minimize/restore animation, update ManagedShell

### DIFF
--- a/RetroBar/Controls/ShowDesktopButton.xaml.cs
+++ b/RetroBar/Controls/ShowDesktopButton.xaml.cs
@@ -102,7 +102,7 @@ namespace RetroBar.Controls
             OpenDisplayPropertiesCpl();
         }
 
-        private void HandleWindowActivated(object sender, WindowActivatedEventArgs e)
+        private void HandleWindowActivated(object sender, WindowEventArgs e)
         {
             if (ShowDesktop.IsChecked == true)
             {

--- a/RetroBar/Controls/TaskButton.xaml.cs
+++ b/RetroBar/Controls/TaskButton.xaml.cs
@@ -108,6 +108,12 @@ namespace RetroBar.Controls
 
         private void Window_GetButtonRect(ref NativeMethods.ShortRect rect)
         {
+            if (Host?.Host?.Screen.Primary != true && Settings.Instance.MultiMonMode != MultiMonOption.SameAsWindow)
+            {
+                // If there are multiple instances of a button, use the button on the primary display only
+                return;
+            }
+
             Point buttonTopLeft = PointToScreen(new Point(0, 0));
             Point buttonBottomRight = PointToScreen(new Point(ActualWidth, ActualHeight));
             rect.Top = (short)buttonTopLeft.Y;

--- a/RetroBar/Controls/TaskButton.xaml.cs
+++ b/RetroBar/Controls/TaskButton.xaml.cs
@@ -94,6 +94,7 @@ namespace RetroBar.Controls
 
             if (Window != null)
             {
+                Window.GetButtonRect += Window_GetButtonRect;
                 Window.PropertyChanged += Window_PropertyChanged;
             }
 
@@ -103,6 +104,16 @@ namespace RetroBar.Controls
             }
 
             _isLoaded = true;
+        }
+
+        private void Window_GetButtonRect(ref NativeMethods.ShortRect rect)
+        {
+            Point buttonTopLeft = PointToScreen(new Point(0, 0));
+            Point buttonBottomRight = PointToScreen(new Point(ActualWidth, ActualHeight));
+            rect.Top = (short)buttonTopLeft.Y;
+            rect.Left = (short)buttonTopLeft.X;
+            rect.Bottom = (short)buttonBottomRight.Y;
+            rect.Right = (short)buttonBottomRight.X;
         }
 
         private void Window_PropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -124,6 +135,7 @@ namespace RetroBar.Controls
 
             if (Window != null)
             {
+                Window.GetButtonRect -= Window_GetButtonRect;
                 Window.PropertyChanged -= Window_PropertyChanged;
             }
 
@@ -141,9 +153,9 @@ namespace RetroBar.Controls
             int ws = Window.WindowStyles;
 
             // disable window operations depending on current window state. originally tried implementing via bindings but found there is no notification we get regarding maximized state
-            MaximizeMenuItem.IsEnabled = (wss != NativeMethods.WindowShowStyle.ShowMaximized && (ws & (int)NativeMethods.WindowStyles.WS_MAXIMIZEBOX) != 0);
-            MinimizeMenuItem.IsEnabled = (wss != NativeMethods.WindowShowStyle.ShowMinimized && (ws & (int)NativeMethods.WindowStyles.WS_MINIMIZEBOX) != 0);
-            if (RestoreMenuItem.IsEnabled = (wss != NativeMethods.WindowShowStyle.ShowNormal))
+            MaximizeMenuItem.IsEnabled = wss != NativeMethods.WindowShowStyle.ShowMaximized && (ws & (int)NativeMethods.WindowStyles.WS_MAXIMIZEBOX) != 0;
+            MinimizeMenuItem.IsEnabled = wss != NativeMethods.WindowShowStyle.ShowMinimized && (ws & (int)NativeMethods.WindowStyles.WS_MINIMIZEBOX) != 0;
+            if (RestoreMenuItem.IsEnabled = wss != NativeMethods.WindowShowStyle.ShowNormal)
             {
                 CloseMenuItem.FontWeight = FontWeights.Normal;
                 RestoreMenuItem.FontWeight = FontWeights.Bold;
@@ -154,7 +166,7 @@ namespace RetroBar.Controls
                 RestoreMenuItem.FontWeight = FontWeights.Normal;
             }
             MoveMenuItem.IsEnabled = wss == NativeMethods.WindowShowStyle.ShowNormal;
-            SizeMenuItem.IsEnabled = (wss == NativeMethods.WindowShowStyle.ShowNormal && (ws & (int)NativeMethods.WindowStyles.WS_MAXIMIZEBOX) != 0);
+            SizeMenuItem.IsEnabled = wss == NativeMethods.WindowShowStyle.ShowNormal && (ws & (int)NativeMethods.WindowStyles.WS_MAXIMIZEBOX) != 0;
         }
 
         private void CloseMenuItem_OnClick(object sender, RoutedEventArgs e)
@@ -189,7 +201,7 @@ namespace RetroBar.Controls
 
         private void AppButton_OnClick(object sender, RoutedEventArgs e)
         {
-            if (PressedWindowState == ApplicationWindow.WindowState.Active)
+            if (PressedWindowState == ApplicationWindow.WindowState.Active && Window?.CanMinimize == true)
             {
                 Window?.Minimize();
             }

--- a/RetroBar/Controls/TaskButton.xaml.cs
+++ b/RetroBar/Controls/TaskButton.xaml.cs
@@ -160,7 +160,7 @@ namespace RetroBar.Controls
 
             // disable window operations depending on current window state. originally tried implementing via bindings but found there is no notification we get regarding maximized state
             MaximizeMenuItem.IsEnabled = wss != NativeMethods.WindowShowStyle.ShowMaximized && (ws & (int)NativeMethods.WindowStyles.WS_MAXIMIZEBOX) != 0;
-            MinimizeMenuItem.IsEnabled = wss != NativeMethods.WindowShowStyle.ShowMinimized && (ws & (int)NativeMethods.WindowStyles.WS_MINIMIZEBOX) != 0;
+            MinimizeMenuItem.IsEnabled = wss != NativeMethods.WindowShowStyle.ShowMinimized && Window.CanMinimize;
             if (RestoreMenuItem.IsEnabled = wss != NativeMethods.WindowShowStyle.ShowNormal)
             {
                 CloseMenuItem.FontWeight = FontWeights.Normal;

--- a/RetroBar/RetroBar.csproj
+++ b/RetroBar/RetroBar.csproj
@@ -42,7 +42,7 @@
 
   <ItemGroup>
     <PackageReference Include="gong-wpf-dragdrop" Version="3.1.1" />
-    <PackageReference Include="ManagedShell" Version="0.0.285" />
+    <PackageReference Include="ManagedShell" Version="0.0.296" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
The Windows minimize/restore animations now correctly use the RetroBar taskbar button location. If the button is on multiple taskbars, the primary is used. Fixes #254

Other relevant improvements from the ManagedShell update:

- Performance improvements on Windows 8 and newer
- Windows that intentionally mark themselves as non-rude no longer trigger full-screen logic
- Fix auto-hide taskbar initial position when on a secondary screen with high DPI
- Fix disabled windows, which can't be restored, being allowed to minimize