### PR TITLE
Use active style when context menu is open

### DIFF
--- a/RetroBar/Controls/TaskButton.xaml
+++ b/RetroBar/Controls/TaskButton.xaml
@@ -45,7 +45,8 @@
             </TextBlock>
         </Grid>
         <Button.ContextMenu>
-            <ContextMenu>
+            <ContextMenu Opened="ContextMenu_OpenedOrClosed"
+                         Closed="ContextMenu_OpenedOrClosed">
                 <MenuItem Header="{DynamicResource restore}"
                           Click="RestoreMenuItem_OnClick"
                           Name="RestoreMenuItem">

--- a/RetroBar/Controls/TaskButton.xaml.cs
+++ b/RetroBar/Controls/TaskButton.xaml.cs
@@ -286,5 +286,10 @@ namespace RetroBar.Controls
             }
         }
         #endregion
+
+        private void ContextMenu_OpenedOrClosed(object sender, RoutedEventArgs e)
+        {
+            BindingOperations.GetMultiBindingExpression(AppButton, StyleProperty).UpdateTarget();
+        }
     }
 }

--- a/RetroBar/Converters/TaskButtonStyleConverter.cs
+++ b/RetroBar/Converters/TaskButtonStyleConverter.cs
@@ -15,7 +15,7 @@ namespace RetroBar.Converters
                 return null;
             }
 
-            if (fxElement.ContextMenu.IsOpen)
+            if (fxElement.ContextMenu?.IsOpen == true)
             {
                 // Always show as active with an open context menu
                 return fxElement.FindResource("TaskButtonActive");

--- a/RetroBar/Converters/TaskButtonStyleConverter.cs
+++ b/RetroBar/Converters/TaskButtonStyleConverter.cs
@@ -15,19 +15,17 @@ namespace RetroBar.Converters
                 return null;
             }
 
+            if (fxElement.ContextMenu.IsOpen)
+            {
+                // Always show as active with an open context menu
+                return fxElement.FindResource("TaskButtonActive");
+            }
+
             // Default style is Inactive...
             var fxStyle = fxElement.FindResource("TaskButton");
 
-            if (values[1] == null)
+            if (values[1] is ApplicationWindow.WindowState state)
             {
-                // Default - couldn't get window state.
-                return fxStyle;
-            }
-
-            if (values[1] is ApplicationWindow.WindowState)
-            {
-                ApplicationWindow.WindowState state = (ApplicationWindow.WindowState) values[1];
-
                 switch (state)
                 {
                     case ApplicationWindow.WindowState.Active:


### PR DESCRIPTION
Addresses the visual portion of #1034.

I don't think activating the window when right-clicking is a good idea, as that breaks WPF focus expectations.