### PR TITLE
Add option to show clock seconds (#217)

### DIFF
--- a/RetroBar/Controls/Clock.xaml.cs
+++ b/RetroBar/Controls/Clock.xaml.cs
@@ -152,15 +152,15 @@ namespace RetroBar.Controls
                 _userCulture = new CultureInfo("en-US");
             }
 
-            if (Settings.Instance.ShowClockSeconds)
-            {
-                _userCulture.DateTimeFormat.ShortTimePattern = _userCulture.DateTimeFormat.LongTimePattern;
-            }
-
             // Make mutable if necessary...
             if (_userCulture.IsReadOnly)
             {
                 _userCulture = (CultureInfo)_userCulture.Clone();
+            }
+
+            if (Settings.Instance.ShowClockSeconds)
+            {
+                _userCulture.DateTimeFormat.ShortTimePattern = _userCulture.DateTimeFormat.LongTimePattern;
             }
 
             SetConverterCultureRecursively(this, _userCulture);

--- a/RetroBar/Controls/Clock.xaml.cs
+++ b/RetroBar/Controls/Clock.xaml.cs
@@ -90,6 +90,10 @@ namespace RetroBar.Controls
                     StopClock();
                 }
             }
+            else if (e.PropertyName == nameof(Settings.ShowClockSeconds))
+            {
+                UpdateUserCulture();
+            }
         }
 
         private void Clock_Tick(object sender, EventArgs args)
@@ -146,6 +150,11 @@ namespace RetroBar.Controls
             {
                 ShellLogger.Error($"Clock: Unable to get the user culture: {e.Message}, defaulting to en-US");
                 _userCulture = new CultureInfo("en-US");
+            }
+
+            if (Settings.Instance.ShowClockSeconds)
+            {
+                _userCulture.DateTimeFormat.ShortTimePattern = _userCulture.DateTimeFormat.LongTimePattern;
             }
 
             // Make mutable if necessary...

--- a/RetroBar/Languages/English.xaml
+++ b/RetroBar/Languages/English.xaml
@@ -76,6 +76,7 @@
     <s:String x:Key="check_for_updates">Check for u_pdates</s:String>
     <s:String x:Key="show_exit_menu_item">Show E_xit option in right-click menu</s:String>
     <s:String x:Key="slide_taskbar_buttons">Slid_e taskbar buttons</s:String>
+    <s:String x:Key="show_clock_seconds">S_how seconds in the clock</s:String>
     <s:String x:Key="ok_dialog">OK</s:String>
 
     <s:String x:Key="customize_notifications">Customize Notifications</s:String>

--- a/RetroBar/Languages/中文(简体).xaml
+++ b/RetroBar/Languages/中文(简体).xaml
@@ -73,6 +73,7 @@
     <s:String x:Key="taskbar_scale_current">当前设置: {0}%</s:String>
     <s:String x:Key="debug_logging">启用调试日志记录(_D)</s:String>
     <s:String x:Key="check_for_updates">检查更新(_U)</s:String>
+    <s:String x:Key="show_clock_seconds">时钟显示秒数</s:String>
     <s:String x:Key="ok_dialog">确定</s:String>
 
     <s:String x:Key="customize_notifications">自定义通知</s:String>

--- a/RetroBar/PropertiesWindow.xaml
+++ b/RetroBar/PropertiesWindow.xaml
@@ -312,6 +312,10 @@
                                       IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowClock, UpdateSourceTrigger=PropertyChanged}">
                                 <Label Content="{DynamicResource show_clock}" />
                             </CheckBox>
+                            <CheckBox x:Name="cbShowClockSeconds"
+                                      IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowClockSeconds, UpdateSourceTrigger=PropertyChanged}">
+                                <Label Content="{DynamicResource show_clock_seconds}" />
+                            </CheckBox>
                             <CheckBox x:Name="cbShowInputLanguage"
                                       IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowInputLanguage, UpdateSourceTrigger=PropertyChanged}">
                                 <Label Content="{DynamicResource show_input_language}" />

--- a/RetroBar/Utilities/Settings.cs
+++ b/RetroBar/Utilities/Settings.cs
@@ -354,6 +354,13 @@ namespace RetroBar.Utilities
             get => _slideTaskbarButtons;
             set => Set(ref _slideTaskbarButtons, value);
         }
+
+        private bool _showClockSeconds = false;
+        public bool ShowClockSeconds
+        {
+            get => _showClockSeconds;
+            set => Set(ref _showClockSeconds, value);
+        }
         #endregion
 
         #region Old Properties


### PR DESCRIPTION
This option changes the time from the short format to the long format, which matches the behavior of the option built in to Windows as well.

Fixes #217 