### PR TITLE
Fix task thumbnail not updating and stretching

### DIFF
--- a/RetroBar/Controls/TaskThumbnail.xaml.cs
+++ b/RetroBar/Controls/TaskThumbnail.xaml.cs
@@ -191,7 +191,7 @@ namespace RetroBar.Controls
             {
                 Refresh();
                 // once loaded, we need to refresh the thumbnail...
-                CompositionTarget.Rendering += (s, a) => Dispatcher.BeginInvoke(DispatcherPriority.Render, new Action(Refresh));
+                CompositionTarget.Rendering += (s, a) => Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(Refresh));
             }
 
             _toolTipTimer.Start();

--- a/RetroBar/Controls/TaskThumbnail.xaml.cs
+++ b/RetroBar/Controls/TaskThumbnail.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Interop;
+using System.Windows.Media;
 using System.Windows.Threading;
 using ManagedShell.Interop;
 
@@ -187,7 +188,11 @@ namespace RetroBar.Controls
             DpiScale = PresentationSource.FromVisual(this).CompositionTarget.TransformToDevice.M11;
 
             if (NativeMethods.DwmIsCompositionEnabled() && SourceWindowHandle != IntPtr.Zero && Handle != IntPtr.Zero && NativeMethods.DwmRegisterThumbnail(Handle, SourceWindowHandle, out _thumbHandle) == 0)
+            {
                 Refresh();
+                // once loaded, we need to refresh the thumbnail...
+                CompositionTarget.Rendering += (s, a) => Dispatcher.BeginInvoke(DispatcherPriority.Render, new Action(Refresh));
+            }
 
             _toolTipTimer.Start();
         }


### PR DESCRIPTION
AIMP is especially affected when displaying album art in the preview. It takes a while to update, it's slightly noticeable, but it's still an improvement.

Before:
![beforedapr](https://github.com/user-attachments/assets/65e12b32-9b05-4a58-9b63-c2b0214ce8d7)

After this PR:
![afterdapr](https://github.com/user-attachments/assets/e30860f3-ba13-4057-8f6e-ecf49186f28e)
