### PR TITLE
Fix occasional empty taskbar when changing theme

### DIFF
--- a/RetroBar/Controls/NotifyIconList.xaml
+++ b/RetroBar/Controls/NotifyIconList.xaml
@@ -3,7 +3,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:RetroBar.Controls"
              xmlns:converters="clr-namespace:RetroBar.Converters"
-             Loaded="NotifyIconList_OnLoaded"
              Unloaded="NotifyIconList_OnUnloaded">
     <UserControl.Resources>
         <ResourceDictionary>

--- a/RetroBar/Controls/NotifyIconList.xaml.cs
+++ b/RetroBar/Controls/NotifyIconList.xaml.cs
@@ -68,11 +68,6 @@ namespace RetroBar.Controls
             }
         }
 
-        private void NotifyIconList_OnLoaded(object sender, RoutedEventArgs e)
-        {
-            SetNotificationAreaCollections();
-        }
-
         private void SetNotificationAreaCollections()
         {
             if (!_isLoaded && NotificationArea != null)

--- a/RetroBar/Controls/NotifyIconList.xaml.cs
+++ b/RetroBar/Controls/NotifyIconList.xaml.cs
@@ -22,7 +22,7 @@ namespace RetroBar.Controls
         private CollectionViewSource pinnedNotifyIconsSource;
         private ObservableCollection<ManagedShell.WindowsTray.NotifyIcon> promotedIcons = new ObservableCollection<ManagedShell.WindowsTray.NotifyIcon>();
 
-        public static DependencyProperty NotificationAreaProperty = DependencyProperty.Register("NotificationArea", typeof(NotificationArea), typeof(NotifyIconList));
+        public static DependencyProperty NotificationAreaProperty = DependencyProperty.Register("NotificationArea", typeof(NotificationArea), typeof(NotifyIconList), new PropertyMetadata(NotificationAreaChangedCallback));
 
         public NotificationArea NotificationArea
         {
@@ -70,6 +70,11 @@ namespace RetroBar.Controls
 
         private void NotifyIconList_OnLoaded(object sender, RoutedEventArgs e)
         {
+            SetNotificationAreaCollections();
+        }
+
+        private void SetNotificationAreaCollections()
+        {
             if (!_isLoaded && NotificationArea != null)
             {
                 CompositeCollection allNotifyIcons = new CompositeCollection();
@@ -104,6 +109,14 @@ namespace RetroBar.Controls
                 }
 
                 _isLoaded = true;
+            }
+        }
+
+        private static void NotificationAreaChangedCallback(DependencyObject sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (sender is NotifyIconList notifyIconList && e.OldValue == null && e.NewValue != null)
+            {
+                notifyIconList.SetNotificationAreaCollections();
             }
         }
 

--- a/RetroBar/Controls/TaskButton.xaml.cs
+++ b/RetroBar/Controls/TaskButton.xaml.cs
@@ -74,13 +74,6 @@ namespace RetroBar.Controls
             animation.Duration = new Duration(TimeSpan.FromMilliseconds(250));
             animation.FillBehavior = FillBehavior.Stop;
             animation.EasingFunction = ease;
-            animation.CurrentStateInvalidated += (object sender, EventArgs e) => {
-                // If the animation gets interrupted for some reason, just complete it
-                if (((AnimationClock)sender).CurrentState == ClockState.Stopped && Host != null && Width != Host.ButtonWidth)
-                {
-                    Width = Host.ButtonWidth;
-                }
-            };
             Storyboard.SetTarget(animation, this);
             Storyboard.SetTargetProperty(animation, new PropertyPath(WidthProperty));
 

--- a/RetroBar/Controls/TaskList.xaml.cs
+++ b/RetroBar/Controls/TaskList.xaml.cs
@@ -71,7 +71,6 @@ namespace RetroBar.Controls
 
         private void TaskList_OnLoaded(object sender, RoutedEventArgs e)
         {
-            SetTasksCollection();
             SetStyles();
         }
 

--- a/RetroBar/Controls/TaskList.xaml.cs
+++ b/RetroBar/Controls/TaskList.xaml.cs
@@ -29,7 +29,7 @@ namespace RetroBar.Controls
             set { SetValue(ButtonWidthProperty, value); }
         }
 
-        public static DependencyProperty TasksProperty = DependencyProperty.Register("Tasks", typeof(Tasks), typeof(TaskList));
+        public static DependencyProperty TasksProperty = DependencyProperty.Register("Tasks", typeof(Tasks), typeof(TaskList), new PropertyMetadata(TasksChangedCallback));
 
         public Tasks Tasks
         {
@@ -71,6 +71,12 @@ namespace RetroBar.Controls
 
         private void TaskList_OnLoaded(object sender, RoutedEventArgs e)
         {
+            SetTasksCollection();
+            SetStyles();
+        }
+
+        private void SetTasksCollection()
+        {
             if (!isLoaded && Tasks != null)
             {
                 taskbarItems = Tasks.CreateGroupedWindowsCollection();
@@ -86,8 +92,14 @@ namespace RetroBar.Controls
 
                 isLoaded = true;
             }
+        }
 
-            SetStyles();
+        private static void TasksChangedCallback(DependencyObject sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (sender is TaskList taskList && e.OldValue == null && e.NewValue != null)
+            {
+                taskList.SetTasksCollection();
+            }
         }
 
         private void Settings_PropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
Sometimes the bound dependency properties are not set before the Loaded event is fired, so added a change handler.

Also removed the earlier incorrect fix.