### PR TITLE
Notify WindowManager of work area change

### DIFF
--- a/RetroBar/Taskbar.xaml.cs
+++ b/RetroBar/Taskbar.xaml.cs
@@ -123,6 +123,10 @@ namespace RetroBar
                 // If the color scheme changes, re-apply the current theme to get updated colors.
                 _dictionaryManager.SetThemeFromSettings();
             }
+            else if (msg == (int)NativeMethods.WM.SETTINGCHANGE && wParam == (IntPtr)NativeMethods.SPI.SETWORKAREA && Settings.Instance.ShowMultiMon)
+            {
+                windowManager.NotifyWorkAreaChange();
+            }
 
             return IntPtr.Zero;
         }

--- a/RetroBar/Utilities/WindowManager.cs
+++ b/RetroBar/Utilities/WindowManager.cs
@@ -64,16 +64,26 @@ namespace RetroBar.Utilities
             }
         }
 
+        public void NotifyWorkAreaChange()
+        {
+            ShellLogger.Debug($"WindowManager: Work area change notification received");
+            handleDisplayChange();
+        }
+
         public void NotifyDisplayChange(ScreenSetupReason reason)
         {
-            ShellLogger.Debug($"WindowManager: Display change notification received ({reason})");
-
             if (reason == ScreenSetupReason.DwmChange)
             {
                 // RetroBar doesn't care when DWM is toggled
                 return;
             }
 
+            ShellLogger.Debug($"WindowManager: Display change notification received ({reason})");
+            handleDisplayChange();
+        }
+
+        private void handleDisplayChange()
+        {
             _pendingDisplayEvents++;
 
             if (_isSettingDisplays)
@@ -167,7 +177,6 @@ namespace RetroBar.Utilities
                     Screen current = Screen.AllScreens[i];
                     if (!(_screenState[i].Bounds == current.Bounds && _screenState[i].DeviceName == current.DeviceName && _screenState[i].Primary == current.Primary))
                     {
-
                         same = false;
                         break;
                     }


### PR DESCRIPTION
Sometimes when we receive a device change notification, the system does not immediately return all of the displays. The work area will always change after a monitor is added/removed, so use that to handle these cases.

Fixes #1087 