### PR TITLE
Refactor HotkeyManager for improved readability and organization

### DIFF
--- a/RetroBar/Languages/English.xaml
+++ b/RetroBar/Languages/English.xaml
@@ -84,7 +84,6 @@
         <s:String>Switch tasks</s:String>
         <s:String>Open Quick Launch item</s:String>
     </x:Array>
-    <s:String x:Key="hotkeys_quick_launch">Taskbar hotkeys launch items in Quick Launch</s:String>
     <s:String x:Key="hotkey_warning_title">RetroBar Hotkeys</s:String>
     <s:String x:Key="hotkey_warning_text">RetroBar will override Windows taskbar hotkeys. Even if RetroBar is closed, they will not be restored to Windows until you log out and back in.</s:String>
     <s:String x:Key="ok_dialog">OK</s:String>

--- a/RetroBar/Languages/español.xaml
+++ b/RetroBar/Languages/español.xaml
@@ -84,7 +84,6 @@
         <s:String>Alternar tareas</s:String>
         <s:String>Abrir elementos de inicio rápido</s:String>
     </x:Array>
-    <s:String x:Key="hotkeys_quick_launch">Teclas de acceso rápido de la barra de tareas abren elementos de inicio rápido</s:String>
     <s:String x:Key="hotkey_warning_title">Teclas de acceso rápido de RetroBar</s:String>
     <s:String x:Key="hotkey_warning_text">RetroBar sustituirá las teclas de acceso rápido de la barra de tareas de Windows. Aunque cierre RetroBar, no se restaurarán en Windows hasta que cierre la sesión y vuelva a iniciarla.</s:String>
     <s:String x:Key="ok_dialog">Aceptar</s:String>

--- a/RetroBar/Languages/español.xaml
+++ b/RetroBar/Languages/español.xaml
@@ -8,8 +8,6 @@
     <s:String x:Key="taskbar_appearance">Apariencia de barra de tareas</s:String>
     <s:String x:Key="notification_area">Área de notificación</s:String>
     <s:String x:Key="autostart">_Iniciar automáticamente al iniciar sesión</s:String>
-    <s:String x:Key="override_hotkeys">Anular _hotkeys de barra de tareas (Win + [1-9])</s:String>
-    <s:String x:Key="hotkeys_quick_launch">Hotkeys de barra de tareas lanzan objetos en el inicio rápido</s:String>
     <s:String x:Key="language_text">Idi_oma:</s:String>
     <s:String x:Key="language_tip">Seleccione el idioma a usar.</s:String>
     <s:String x:Key="theme_text">_Tema:</s:String>
@@ -80,6 +78,15 @@
     <s:String x:Key="slide_taskbar_buttons">Deslizar _botones de la barra de tareas</s:String>
     <s:String x:Key="show_clock_seconds">Mostrar _segundos en el reloj</s:String>
     <s:String x:Key="open_custom_themes_folder">Abrir carpeta de temas personalizados</s:String>
+    <s:String x:Key="win_num_hotkeys_action">Acción de teclas de acceso _rápido Win+[0-9]:</s:String>
+    <x:Array x:Key="win_num_hotkeys_action_values" Type="s:String">
+        <s:String>Predeterminado de Windows</s:String>
+        <s:String>Alternar tareas</s:String>
+        <s:String>Abrir elementos de inicio rápido</s:String>
+    </x:Array>
+    <s:String x:Key="hotkeys_quick_launch">Teclas de acceso rápido de la barra de tareas abren elementos de inicio rápido</s:String>
+    <s:String x:Key="hotkey_warning_title">Teclas de acceso rápido de RetroBar</s:String>
+    <s:String x:Key="hotkey_warning_text">RetroBar sustituirá las teclas de acceso rápido de la barra de tareas de Windows. Aunque cierre RetroBar, no se restaurarán en Windows hasta que cierre la sesión y vuelva a iniciarla.</s:String>
     <s:String x:Key="ok_dialog">Aceptar</s:String>
 
     <s:String x:Key="customize_notifications">Personalizar notificaciones</s:String>

--- a/RetroBar/RetroBar.csproj
+++ b/RetroBar/RetroBar.csproj
@@ -42,7 +42,7 @@
 
   <ItemGroup>
     <PackageReference Include="gong-wpf-dragdrop" Version="3.1.1" />
-    <PackageReference Include="ManagedShell" Version="0.0.320" />
+    <PackageReference Include="ManagedShell" Version="0.0.326" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.2" />
   </ItemGroup>
 

--- a/RetroBar/Utilities/HotkeyManager.cs
+++ b/RetroBar/Utilities/HotkeyManager.cs
@@ -65,7 +65,7 @@ namespace RetroBar.Utilities
 
         private class HotkeyListenerWindow : NativeWindow, IDisposable
         {
-            internal bool IsRegistered;
+            internal bool IsRegistered => _registeredHotkeys.Count > 0;
             private readonly HotkeyManager _manager;
             private readonly HashSet<int> _registeredHotkeys = [];
             private const int WMTRAY_UNREGISTERHOTKEY = (int)WM.USER + 231;
@@ -120,8 +120,6 @@ namespace RetroBar.Utilities
                     RegisterWinKey(VK.KEY_8, 7);
                     RegisterWinKey(VK.KEY_9, 8);
                     RegisterWinKey(VK.KEY_0, 9);
-
-                    IsRegistered = true;
                 }
                 catch (Exception ex)
                 {
@@ -256,8 +254,6 @@ namespace RetroBar.Utilities
 
                 // TODO: Re-register Explorer hotkeys
                 // (maybe sending some undocumented message to the tray again, otherwise, restart Explorer process?)
-
-                IsRegistered = false;
             }
 
             public void Dispose() => DestroyHandle();

--- a/RetroBar/Utilities/HotkeyManager.cs
+++ b/RetroBar/Utilities/HotkeyManager.cs
@@ -199,11 +199,11 @@ namespace RetroBar.Utilities
                     if (success)
                     {
                         _registeredHotkeys.Add(taskIndex);
-                        ShellLogger.Debug($"HotkeyManager: Registered hotkey {modifiers}+{key} with id={taskIndex}");
+                        ShellLogger.Debug($"HotkeyManager: Registered hotkey {modifiers}+{key} with ID={taskIndex}");
                     }
                     else
                     {
-                        ShellLogger.Warning($"HotkeyManager: Failed to register hotkey {modifiers}+{key} with id={taskIndex}");
+                        ShellLogger.Warning($"HotkeyManager: Failed to register hotkey {modifiers}+{key} with ID={taskIndex}");
                     }
 
                     return success;
@@ -228,7 +228,7 @@ namespace RetroBar.Utilities
                     // Exit if no matching hotkey found
                     if (trayHotkeyIndex < 0) return;
 
-                    // Found a match - send unregister message to explorer
+                    // Found a match - send unregister message to Explorer
                     int trayHotkeyId = _trayHotkeyTable[trayHotkeyIndex].Id;
                     SendMessage(_trayWindow, WMTRAY_UNREGISTERHOTKEY, new IntPtr(trayHotkeyId), IntPtr.Zero);
                     ShellLogger.Debug($"HotkeyManager: Sent WMTRAY_UNREGISTERHOTKEY for hotkey id={trayHotkeyId}");
@@ -246,7 +246,7 @@ namespace RetroBar.Utilities
                 foreach (int id in _registeredHotkeys)
                 {
                     UnregisterHotKey(Handle, id);
-                    ShellLogger.Debug($"HotkeyManager: Unregistered hotkey id={id}");
+                    ShellLogger.Debug($"HotkeyManager: Unregistered hotkey ID={id}");
                 }
 
                 _registeredHotkeys.Clear();

--- a/RetroBar/Utilities/HotkeyManager.cs
+++ b/RetroBar/Utilities/HotkeyManager.cs
@@ -264,6 +264,8 @@ namespace RetroBar.Utilities
                 }
 
                 _registeredHotkeys.Clear();
+
+                // TODO: Re-register explorer hotkeys
             }
 
             public void Dispose()

--- a/RetroBar/Utilities/HotkeyManager.cs
+++ b/RetroBar/Utilities/HotkeyManager.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.IO.MemoryMappedFiles;
 using System.Windows.Forms;
 using static ManagedShell.Interop.NativeMethods;
+using static RetroBar.Utilities.Enums;
 
 namespace RetroBar.Utilities
 {
@@ -189,7 +190,7 @@ namespace RetroBar.Utilities
                     bool success = RegisterHotKey(
                         Handle,
                         taskIndex,
-                        HotkeyUtility.MOD_WIN | HotkeyUtility.MOD_NOREPEAT,
+                        (uint)(MOD.WIN | MOD.NOREPEAT),
                         (uint)key);
 
                     if (success)
@@ -216,7 +217,7 @@ namespace RetroBar.Utilities
                 try
                 {
                     // Find key with exactly MOD_WIN modifier (no other modifiers) in the Explorer hotkey table
-                    int trayHotkeyIndex = _trayHotkeyTable.FindIndex(e => e.VirtualKey == (byte)key && e.Modifier == HotkeyUtility.MOD_WIN);
+                    int trayHotkeyIndex = _trayHotkeyTable.FindIndex(e => e.VirtualKey == (byte)key && e.Modifier == (uint)MOD.WIN);
 
                     if (trayHotkeyIndex < 0)
                     {
@@ -258,9 +259,6 @@ namespace RetroBar.Utilities
 
     public static class HotkeyUtility
     {
-        public const uint MOD_WIN = 0x0008; // System.Windows.Input.ModifierKeys.Windows
-        public const uint MOD_NOREPEAT = 0x4000;
-
         /// <summary>
         /// Extracts the Windows hotkey table registered by Shell_TrayWnd from explorer.exe by reading the binary file.
         /// </summary>
@@ -339,7 +337,7 @@ namespace RetroBar.Utilities
 
             // Check that modifier has Windows key flag set and high bits are clear
             byte modifier = bytes[offset + 4];
-            return (modifier & MOD_WIN) != 0 && (modifier & 0xF0) == 0;
+            return (modifier & (uint)MOD.WIN) != 0 && (modifier & 0xF0) == 0;
         }
     }
 
@@ -348,5 +346,20 @@ namespace RetroBar.Utilities
         public int Id;
         public byte VirtualKey;
         public byte Modifier;
+    }
+
+    // TODO: Move to upstream ManagedShell library
+    internal class Enums
+    {
+        // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-registerhotkey
+        [Flags]
+        public enum MOD : uint
+        {
+            ALT = 0x0001,
+            CONTROL = 0x0002,
+            NOREPEAT = 0x4000,
+            SHIFT = 0x0004,
+            WIN = 0x0008 // System.Windows.Input.ModifierKeys.Windows
+        }
     }
 }

--- a/RetroBar/Utilities/HotkeyManager.cs
+++ b/RetroBar/Utilities/HotkeyManager.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.IO.MemoryMappedFiles;
 using System.Windows.Forms;
 using static ManagedShell.Interop.NativeMethods;
-using static RetroBar.Utilities.Enums;
 
 namespace RetroBar.Utilities
 {
@@ -349,20 +348,5 @@ namespace RetroBar.Utilities
         public int Id;
         public byte VirtualKey;
         public byte Modifier;
-    }
-
-    // TODO: Move to upstream ManagedShell library
-    internal class Enums
-    {
-        // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-registerhotkey
-        [Flags]
-        public enum MOD : uint
-        {
-            ALT = 0x0001,
-            CONTROL = 0x0002,
-            NOREPEAT = 0x4000,
-            SHIFT = 0x0004,
-            WIN = 0x0008 // System.Windows.Input.ModifierKeys.Windows
-        }
     }
 }

--- a/RetroBar/Utilities/HotkeyManager.cs
+++ b/RetroBar/Utilities/HotkeyManager.cs
@@ -1,23 +1,28 @@
 ﻿using ManagedShell.Common.Helpers;
 using ManagedShell.Common.Logging;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.IO.MemoryMappedFiles;
 using System.Windows.Forms;
 using static ManagedShell.Interop.NativeMethods;
 
 namespace RetroBar.Utilities
 {
+    /// <summary>
+    /// Manages application hotkeys by overriding Explorer's built-in Win+VK mappings.
+    /// </summary>
     public class HotkeyManager : IDisposable
     {
-        public HotkeyListenerWindow listenerWindow;
+        private readonly HotkeyListenerWindow _listenerWindow;
 
         public HotkeyManager()
         {
-            listenerWindow = new HotkeyListenerWindow(this);
+            _listenerWindow = new HotkeyListenerWindow(this);
 
             if (Settings.Instance.OverrideHotkeys)
             {
-                listenerWindow.RegisterHotkeys();
+                _listenerWindow.RegisterHotkeys();
             }
 
             Settings.Instance.PropertyChanged += Settings_PropertyChanged;
@@ -27,10 +32,10 @@ namespace RetroBar.Utilities
         {
             if (Settings.Instance.OverrideHotkeys)
             {
-                listenerWindow.UnregisterHotkeys();
+                _listenerWindow.UnregisterHotkeys();
             }
 
-            listenerWindow?.Dispose();
+            _listenerWindow?.Dispose();
         }
 
         #region Events
@@ -47,19 +52,24 @@ namespace RetroBar.Utilities
             {
                 if (Settings.Instance.OverrideHotkeys)
                 {
-                    listenerWindow.RegisterHotkeys();
+                    _listenerWindow.RegisterHotkeys();
                 }
                 else
                 {
-                    listenerWindow.UnregisterHotkeys();
+                    _listenerWindow.UnregisterHotkeys();
                 }
             }
         }
         #endregion
 
-        public class HotkeyListenerWindow : NativeWindow, IDisposable
+        private class HotkeyListenerWindow : NativeWindow, IDisposable
         {
             private readonly HotkeyManager _manager;
+            private const int HOTKEY_BASE_ID = 500;
+            private readonly HashSet<int> _registeredHotkeys = [];
+            private const int EXPLORER_UNREGISTER_HOTKEY = (int)WM.USER + 231;
+            private List<HotkeyEntry> _explorerHotkeyTable;
+            private IntPtr _trayWindow;
 
             public HotkeyListenerWindow(HotkeyManager manager)
             {
@@ -71,207 +81,264 @@ namespace RetroBar.Utilities
             {
                 if (m.Msg == (int)WM.HOTKEY)
                 {
-                    int hotkeyId = (int)m.WParam;
-
-                    if (hotkeyId >= 0 && hotkeyId <= 9) // 0-9: Quick switch hotkeys
+                    int hotkeyId = m.WParam.ToInt32();
+                    if (_registeredHotkeys.Contains(hotkeyId))
                     {
-                        TaskbarHotkeyEventArgs args = new() { index = hotkeyId };
-                        _manager.TaskbarHotkeyPressed?.Invoke(this, args);
+                        _manager.TaskbarHotkeyPressed?.Invoke(this, new TaskbarHotkeyEventArgs { index = hotkeyId });
+                        ShellLogger.Debug($"HotkeyManager: Hotkey pressed: ID={hotkeyId}");
                     }
                 }
 
                 base.WndProc(ref m);
             }
 
-            #region Explorer hotkey table detection
-
-            /// <summary>
-            /// Contains logic to locate Explorer’s built‑in taskbar hotkey table index at runtime.
-            /// </summary>
-            private static class ExplorerHotkeyTable
-            {
-                // Pattern of four consecutive hotkey entries for Win+1…Win+4 (each entry is two DWORDs: key code and modifiers)
-                private static readonly byte[] Pattern =
-                [
-                    0x31,0x00,0x00,0x00, 0x08,0x00,0x00,0x00,
-                    0x32,0x00,0x00,0x00, 0x08,0x00,0x00,0x00,
-                    0x33,0x00,0x00,0x00, 0x08,0x00,0x00,0x00,
-                    0x34,0x00,0x00,0x00, 0x08,0x00,0x00,0x00,
-                ];
-
-                // Fallback index in case detection fails (known working default on recent Windows versions)
-                private const int DefaultIndex = 17;
-
-                // Size in bytes of one hotkey entry (two 32-bit values)
-                private const int EntrySize = sizeof(int) * 2;
-
-                // Cached result to avoid repeated file scans
-                private static int? _cachedIndex;
-
-                /// <summary>
-                /// Scans the local Explorer.exe to find the zero‑based index of the first taskbar hotkey entry.
-                /// </summary>
-                /// <returns>
-                /// The index of the first taskbar hotkey entry in Explorer’s hotkey table, or <see cref="DefaultIndex" /> if detection fails.
-                /// </returns>
-                public static int GetIndex()
-                {
-                    if (_cachedIndex.HasValue) return _cachedIndex.Value;
-
-                    try
-                    {
-                        // Read Explorer binary into memory
-                        var systemRoot = Environment.GetEnvironmentVariable("SystemRoot");
-                        var path = Path.Combine(systemRoot!, "explorer.exe");
-                        byte[] data = File.ReadAllBytes(path);
-
-                        // Locate our known pattern (Win+1…4)
-                        int offset = data.AsSpan().IndexOf(Pattern);
-                        if (offset < 0)
-                            throw new InvalidOperationException("Pattern not found in explorer.exe");
-
-                        // Walk backwards entry-by-entry until we hit an all-zero entry (table header)
-                        int index = 0;
-                        int position = offset - EntrySize;
-                        while (position >= 0)
-                        {
-                            // Check the two consecutive DWORDs
-                            bool isEmpty = true;
-                            for (int i = 0; i < EntrySize; i++)
-                            {
-                                if (data[position + i] != 0)
-                                {
-                                    isEmpty = false;
-                                    break;
-                                }
-                            }
-
-                            if (isEmpty)
-                                break;
-
-                            index++;
-                            position -= EntrySize;
-                        }
-
-                        _cachedIndex = index;
-                    }
-                    catch (Exception ex)
-                    {
-                        ShellLogger.Warning($"HotkeyManager: Explorer hotkey index detection failed: {ex.Message}");
-                        _cachedIndex = DefaultIndex;
-                    }
-
-                    return _cachedIndex.Value;
-                }
-            }
-
-            #endregion
-
-            /// <summary>
-            /// Custom window message to ask Explorer to unregister a hotkey.
-            /// </summary>
-            private const int EXPLORER_UNREGISTER_HOTKEY = (int)WM.USER + 231;
-
-            /// <summary>
-            /// Modifier flag to suppress auto‑repeat on hotkey registrations.
-            /// </summary>
-            private const uint MOD_NOREPEAT = 0x4000;
-
-            private static void UnregisterExplorerHotkey(IntPtr trayWnd, int id)
-            {
-                // Send message to explorer to unregister its hotkey
-                if (trayWnd != IntPtr.Zero)
-                {
-                    SendMessage(trayWnd,
-                        EXPLORER_UNREGISTER_HOTKEY,
-                        (IntPtr)id,
-                        IntPtr.Zero
-                    );
-                }
-            }
-
-            private void UnregisterExplorerHotkeys()
-            {
-                // Send message to explorer to unregister its hotkeys
-                IntPtr trayWnd = WindowHelper.FindWindowsTray(WindowHelper.FindWindowsTray(IntPtr.Zero));
-                int firstId = ExplorerHotkeyTable.GetIndex() + 500;
-
-                if (trayWnd != IntPtr.Zero)
-                {
-                    UnregisterExplorerHotkey(trayWnd, firstId);
-                    UnregisterExplorerHotkey(trayWnd, firstId + 1);
-                    UnregisterExplorerHotkey(trayWnd, firstId + 2);
-                    UnregisterExplorerHotkey(trayWnd, firstId + 3);
-                    UnregisterExplorerHotkey(trayWnd, firstId + 4);
-                    UnregisterExplorerHotkey(trayWnd, firstId + 5);
-                    UnregisterExplorerHotkey(trayWnd, firstId + 6);
-                    UnregisterExplorerHotkey(trayWnd, firstId + 7);
-                    UnregisterExplorerHotkey(trayWnd, firstId + 8);
-                    UnregisterExplorerHotkey(trayWnd, firstId + 9);
-                }
-            }
-
-            private readonly System.Collections.Generic.HashSet<int> _registeredHotkeys = [];
-
-            private bool RegisterWinKey(VK key, int id)
-            {
-                bool success = RegisterHotKey(
-                    Handle,
-                    id,
-                    (uint)System.Windows.Input.ModifierKeys.Windows | MOD_NOREPEAT,
-                    (uint)key);
-
-                if (success)
-                {
-                    _registeredHotkeys.Add(id);
-                    ShellLogger.Debug($"HotkeyManager: Registered Win+{key} (id {id})");
-                }
-                else
-                {
-                    ShellLogger.Warning($"HotkeyManager: Failed to register Win+{key} (id {id})");
-                }
-
-                return success;
-            }
-
             public void RegisterHotkeys()
             {
-                // Remove explorer hotkeys
-                UnregisterExplorerHotkeys();
+                ShellLogger.Info("HotkeyManager: Registering override hotkeys");
 
-                // Reset any prior registrations
-                _registeredHotkeys.Clear();
+                try
+                {
+                    // Initialize hotkey table and tray window
+                    LoadExplorerResources();
 
-                // Try to register Win[0-9] hotkeys for RetroBar
-                RegisterWinKey(VK.KEY_1, 0);
-                RegisterWinKey(VK.KEY_2, 1);
-                RegisterWinKey(VK.KEY_3, 2);
-                RegisterWinKey(VK.KEY_4, 3);
-                RegisterWinKey(VK.KEY_5, 4);
-                RegisterWinKey(VK.KEY_6, 5);
-                RegisterWinKey(VK.KEY_7, 6);
-                RegisterWinKey(VK.KEY_8, 7);
-                RegisterWinKey(VK.KEY_9, 8);
-                RegisterWinKey(VK.KEY_0, 9);
+                    // Register the number keys
+                    RegisterWinKey(VK.KEY_1, 0);
+                    RegisterWinKey(VK.KEY_2, 1);
+                    RegisterWinKey(VK.KEY_3, 2);
+                    RegisterWinKey(VK.KEY_4, 3);
+                    RegisterWinKey(VK.KEY_5, 4);
+                    RegisterWinKey(VK.KEY_6, 5);
+                    RegisterWinKey(VK.KEY_7, 6);
+                    RegisterWinKey(VK.KEY_8, 7);
+                    RegisterWinKey(VK.KEY_9, 8);
+                    RegisterWinKey(VK.KEY_0, 9);
+                }
+                catch (Exception ex)
+                {
+                    ShellLogger.Warning($"HotkeyManager: Exception during RegisterHotkeys - {ex.Message}");
+                }
+            }
+
+            private void LoadExplorerResources()
+            {
+                // Initialize with empty table as fallback
+                _explorerHotkeyTable = [];
+                _trayWindow = IntPtr.Zero;
+
+                try
+                {
+                    // FIXME: Try to find a better way to get the explorer.exe path, maybe use the handle of the process
+                    string explorerPath = Path.Combine(Environment.GetEnvironmentVariable("SystemRoot")!, "explorer.exe");
+                    if (File.Exists(explorerPath))
+                    {
+                        _explorerHotkeyTable = HotkeyUtility.BuildExplorerHotkeyTableInternal(explorerPath);
+                        ShellLogger.Debug($"HotkeyManager: Found {_explorerHotkeyTable.Count} entries in explorer hotkey table");
+                    }
+                    else
+                    {
+                        // This is bad...
+                        ShellLogger.Warning("HotkeyManager: explorer.exe not found at expected location");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // WTF: Using an older pre-Vista explorer or something else went wrong
+                    ShellLogger.Warning($"HotkeyManager: Failed to build explorer hotkey table - {ex.Message}");
+                }
+
+                try
+                {
+                    _trayWindow = WindowHelper.FindWindowsTray(WindowHelper.FindWindowsTray(IntPtr.Zero));
+                    if (_trayWindow == IntPtr.Zero)
+                    {
+                        ShellLogger.Debug("HotkeyManager: Real explorer tray window not found");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    ShellLogger.Warning($"HotkeyManager: Failed to find real explorer tray window - {ex.Message}");
+                }
+            }
+
+            private bool RegisterWinKey(VK key, int taskIndex)
+            {
+                try
+                {
+                    // Try to unregister from explorer if possible
+                    TryUnregisterExplorerHotkey(key);
+
+                    // Register the hotkey for RetroBar
+                    // (will run even if explorer unregistration failed)
+                    bool success = RegisterHotKey(
+                        Handle,
+                        taskIndex,
+                        HotkeyUtility.MOD_WIN | HotkeyUtility.MOD_NOREPEAT,
+                        (uint)key);
+
+                    if (success)
+                    {
+                        _registeredHotkeys.Add(taskIndex);
+                        ShellLogger.Debug($"HotkeyManager: Registered hotkey Win+{key} with id={taskIndex}");
+                    }
+                    else
+                    {
+                        ShellLogger.Warning($"HotkeyManager: Failed to register hotkey Win+{key}");
+                    }
+
+                    return success;
+                }
+                catch (Exception ex)
+                {
+                    ShellLogger.Warning($"HotkeyManager: Exception registering Win+{key} - {ex.Message}");
+                    return false;
+                }
+            }
+
+            private void TryUnregisterExplorerHotkey(VK key)
+            {
+                // Skip explorer unregistration if we don't have the required info
+                if (_explorerHotkeyTable == null || _explorerHotkeyTable.Count == 0 || _trayWindow == IntPtr.Zero)
+                {
+                    ShellLogger.Debug($"HotkeyManager: Skipping Explorer hotkey unregistration for Win+{key} (resources not available)");
+                    return;
+                }
+
+                try
+                {
+                    // Find key with exactly MOD_WIN modifier (no other modifiers) in the explorer hotkey table
+                    int explorerIndex = _explorerHotkeyTable.FindIndex(
+                        e => e.VirtualKey == (byte)key && e.Modifier == HotkeyUtility.MOD_WIN);
+
+                    if (explorerIndex < 0)
+                    {
+                        ShellLogger.Debug($"HotkeyManager: Win+{key} not found in explorer hotkey table");
+                        return;
+                    }
+
+                    // Calculate the hotkey ID used by explorer
+                    int hotkeyId = HOTKEY_BASE_ID + explorerIndex;
+
+                    // Tell explorer to unregister this hotkey
+                    SendMessage(_trayWindow, EXPLORER_UNREGISTER_HOTKEY, new IntPtr(hotkeyId), IntPtr.Zero);
+                    ShellLogger.Debug($"HotkeyManager: Sent EXPLORER_UNREGISTER_HOTKEY for Win+{key} with id={hotkeyId}");
+                }
+                catch (Exception ex)
+                {
+                    ShellLogger.Warning($"HotkeyManager: Exception unregistering Explorer hotkey Win+{key} - {ex.Message}");
+                }
             }
 
             public void UnregisterHotkeys()
             {
                 // Only unregister those we actually registered
+                ShellLogger.Info("HotkeyManager: Unregistering override hotkeys");
                 foreach (int id in _registeredHotkeys)
                 {
                     UnregisterHotKey(Handle, id);
+                    ShellLogger.Debug($"HotkeyManager: Unregistered hotkey id={id}");
                 }
 
                 _registeredHotkeys.Clear();
 
                 // TODO: Re-register explorer hotkeys
+                // (maybe sending some undocumented message to the tray again, otherwise, restart explorer process?)
             }
 
-            public void Dispose()
-            {
-                DestroyHandle();
-            }
+            public void Dispose() => DestroyHandle();
         }
+    }
+
+    public static class HotkeyUtility
+    {
+        public const uint MOD_WIN = 0x0008; // System.Windows.Input.ModifierKeys.Windows
+        public const uint MOD_NOREPEAT = 0x4000;
+
+        /// <summary>
+        /// Extracts the Windows hotkey table from explorer.exe by reading the binary file.
+        /// </summary>
+        /// <param name="explorerPath">The full path to explorer.exe</param>
+        /// <returns>A list of hotkey entries found in explorer.exe</returns>
+        /// <remarks>
+        /// This method works by scanning explorer.exe for byte patterns that match the structure of hotkey entries.
+        /// It identifies sequences of bytes that follow the pattern where:
+        /// - Each entry is 8 bytes
+        /// - Only byte 0 (virtual key code) and byte 4 (modifier) have non-zero values
+        /// - The modifier has the Windows key flag set
+        ///
+        /// The method finds the longest consecutive sequence of valid entries, which is likely
+        /// the hotkey table used by explorer to register system-wide Windows+Key combinations.
+        /// </remarks>
+        public static List<HotkeyEntry> BuildExplorerHotkeyTableInternal(string explorerPath)
+        {
+            using var mmf = MemoryMappedFile.CreateFromFile(explorerPath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using var stream = mmf.CreateViewStream(0, 0, MemoryMappedFileAccess.Read);
+            using var reader = new BinaryReader(stream);
+            byte[] data = reader.ReadBytes((int)stream.Length);
+
+            var offsets = new List<int>();
+            for (int i = 0; i <= data.Length - 8; i += 8)
+            {
+                if (IsValidEntryAt(data, i))
+                    offsets.Add(i);
+            }
+
+            int bestStart = 0, bestCount = 0;
+            foreach (int start in offsets)
+            {
+                int count = 1;
+                while (offsets.Contains(start + count * 8)) count++;
+                if (count > bestCount)
+                {
+                    bestStart = start;
+                    bestCount = count;
+                }
+            }
+
+            var table = new List<HotkeyEntry>(bestCount);
+            for (int i = 0; i < bestCount; i++)
+            {
+                int off = bestStart + i * 8;
+                table.Add(new HotkeyEntry
+                {
+                    Index = i,
+                    VirtualKey = data[off],
+                    Modifier = data[off + 4]
+                });
+            }
+
+            return table;
+        }
+
+        /// <summary>
+        /// Checks if the bytes at the specified index match the pattern of a Windows hotkey entry in explorer.exe
+        /// </summary>
+        /// <param name="bytes">The byte array to check</param>
+        /// <param name="offset">The offset to start checking at</param>
+        /// <returns>True if the bytes at offset match the hotkey entry pattern</returns>
+        private static bool IsValidEntryAt(byte[] bytes, int offset)
+        {
+            // Entry must be aligned to 8 bytes (hotkey entries are 8 bytes each)
+            const int ENTRY_SIZE = 8;
+            if (offset % ENTRY_SIZE != 0)
+                return false;
+
+            // Only byte 0 (VK code) and byte 4 (modifier) should have values, rest must be zero
+            for (int i = 1; i <= 7; i++)
+            {
+                if (i != 4 && bytes[offset + i] != 0)
+                    return false;
+            }
+
+            // Check that modifier has Windows key flag set and high bits are clear
+            byte modifier = bytes[offset + 4];
+            return (modifier & MOD_WIN) != 0 && (modifier & 0xF0) == 0;
+        }
+    }
+
+    public struct HotkeyEntry
+    {
+        public int Index; // ID
+        public byte VirtualKey;
+        public byte Modifier;
     }
 }


### PR DESCRIPTION
This PR attempts to refactor and improve the clarity of the `HotkeyManager` class code for further maintainability and functionality. Changes include restructuring the hotkey registration/unregistration handling, moving the Explorer hotkey table detection algorithm to a static class, and improving logging and error handling.

### Refactoring and Code Simplification
* Consolidated hotkey registration/unregistration logic into dedicated methods (`RegisterHotkeys` and `UnregisterHotkeys`) and introduced a `HashSet` to track registered hotkeys. This ensures only successfully registered hotkeys are unregistered.
* Replaced inline `NativeMethods` references with `using static ManagedShell.Interop.NativeMethods` for cleaner syntax  (can be undone, I still doubt this actually makes it cleaner, but clearer).
* Replaced public fields with private, readonly fields (e.g., `_listenerWindow` and `_manager`) to improve encapsulation. [[1]](diffhunk://#diff-d4c2f7b91e61e9d6e8ecb5b6f64981df3bb0238b1cf9381e6e68ef15ecf14640L3-R39) [[2]](diffhunk://#diff-d4c2f7b91e61e9d6e8ecb5b6f64981df3bb0238b1cf9381e6e68ef15ecf14640L52-R72)
* Converted the `HotkeyListenerWindow` class to a private nested class and made its constructor arguments readonly for better scoping and immutability.
* Removed unused `using`s.

### Improved Readability
* Added braces to some single-line `if`/`else` statements for better readability.
* Enhanced logging (excessive verbose, may drop in a future commit) with more descriptive messages for hotkey registration failures and Explorer hotkey index detection issues.
* It explicitly declares the registration of hotkeys instead of using a `for` loop.

### New Features
* Introduced a custom `TryUnregisterExplorerHotkey` method to send explicit messages to Explorer for unregistering its hotkeys.
* Added `BuildExplorerHotkeyTableInternal` to dynamically extract the Windows hotkey table from `explorer.exe` (should work with Vista and future versions of explorer).