### PR TITLE
Fix TaskList control leaking

### DIFF
--- a/RetroBar/Controls/TaskList.xaml.cs
+++ b/RetroBar/Controls/TaskList.xaml.cs
@@ -183,12 +183,15 @@ namespace RetroBar.Controls
             if (taskbarItems != null)
             {
                 taskbarItems.CollectionChanged -= GroupedWindows_CollectionChanged;
+                taskbarItems.Filter = null;
             }
 
             if (Host != null)
             {
                 Host.hotkeyManager.TaskbarHotkeyPressed -= TaskList_TaskbarHotkeyPressed;
             }
+
+            Settings.Instance.PropertyChanged -= Settings_PropertyChanged;
 
             isLoaded = false;
         }

--- a/RetroBar/RetroBar.csproj
+++ b/RetroBar/RetroBar.csproj
@@ -42,7 +42,7 @@
 
   <ItemGroup>
     <PackageReference Include="gong-wpf-dragdrop" Version="3.1.1" />
-    <PackageReference Include="ManagedShell" Version="0.0.326" />
+    <PackageReference Include="ManagedShell" Version="0.0.330" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Event handler leaks caused TaskList controls to be retained even after a taskbar window is closed.

Combined with the ManagedShell update, we no longer leak Taskbar windows in memory when displays change.