### PR TITLE
Add support for reordering notification icons via drag-and-drop

### DIFF
--- a/RetroBar/Controls/NotifyIcon.xaml.cs
+++ b/RetroBar/Controls/NotifyIcon.xaml.cs
@@ -119,12 +119,19 @@ namespace RetroBar.Controls
         {
             e.Handled = true;
             Host?.SetTrayHost();
-            TrayIcon?.IconMouseDown(e.ChangedButton, MouseHelper.GetCursorPositionParam(), System.Windows.Forms.SystemInformation.DoubleClickTime);
+            if (e.ChangedButton != MouseButton.Left)
+            {
+                TrayIcon?.IconMouseDown(e.ChangedButton, MouseHelper.GetCursorPositionParam(), System.Windows.Forms.SystemInformation.DoubleClickTime);
+            }
         }
 
         private void NotifyIcon_OnMouseUp(object sender, MouseButtonEventArgs e)
         {
             e.Handled = true;
+            if (e.ChangedButton == MouseButton.Left)
+            {
+                TrayIcon?.IconMouseDown(e.ChangedButton, MouseHelper.GetCursorPositionParam(), System.Windows.Forms.SystemInformation.DoubleClickTime);
+            }
             TrayIcon?.IconMouseUp(e.ChangedButton, MouseHelper.GetCursorPositionParam(), System.Windows.Forms.SystemInformation.DoubleClickTime);
         }
 

--- a/RetroBar/Controls/NotifyIconList.xaml
+++ b/RetroBar/Controls/NotifyIconList.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:RetroBar.Controls"
              xmlns:converters="clr-namespace:RetroBar.Converters"
+             xmlns:dd="urn:gong-wpf-dragdrop"
              Loaded="NotifyIconList_Loaded"
              Unloaded="NotifyIconList_OnUnloaded">
     <UserControl.Resources>
@@ -23,7 +24,10 @@
                       Style="{DynamicResource TrayToggleButton}"/>
         <ItemsControl x:Name="NotifyIcons"
                       Focusable="False"
-                      Style="{DynamicResource NotifyIconItems}">
+                      Style="{DynamicResource NotifyIconItems}"
+                      dd:DragDrop.IsDragSource="True"
+                      dd:DragDrop.IsDropTarget="True"
+                      dd:DragDrop.DragDropContext="NotifyIconList">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>
                     <WrapPanel>

--- a/RetroBar/Controls/NotifyIconList.xaml.cs
+++ b/RetroBar/Controls/NotifyIconList.xaml.cs
@@ -170,8 +170,11 @@ namespace RetroBar.Controls
             SetNotificationAreaCollections();
 
             // Set up drag/drop handler
-            dropHandler = new NotifyIconDropHandler(this);
-            GongSolutions.Wpf.DragDrop.DragDrop.SetDropHandler(NotifyIcons, dropHandler);
+            if (dropHandler == null)
+            {
+                dropHandler = new NotifyIconDropHandler(this);
+                GongSolutions.Wpf.DragDrop.DragDrop.SetDropHandler(NotifyIcons, dropHandler);
+            }
         }
 
         private void NotifyIconList_OnUnloaded(object sender, RoutedEventArgs e)

--- a/RetroBar/Controls/NotifyIconList.xaml.cs
+++ b/RetroBar/Controls/NotifyIconList.xaml.cs
@@ -2,9 +2,9 @@
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
 using System.Windows.Threading;
 using ManagedShell.WindowsTray;
 using RetroBar.Extensions;
@@ -18,9 +18,10 @@ namespace RetroBar.Controls
     public partial class NotifyIconList : UserControl
     {
         private bool _isLoaded;
-        private CollectionViewSource allNotifyIconsSource;
-        private CollectionViewSource pinnedNotifyIconsSource;
+        private readonly ObservableCollection<ManagedShell.WindowsTray.NotifyIcon> allNotifyIcons = new ObservableCollection<ManagedShell.WindowsTray.NotifyIcon>();
+        private readonly ObservableCollection<ManagedShell.WindowsTray.NotifyIcon> pinnedNotifyIcons = new ObservableCollection<ManagedShell.WindowsTray.NotifyIcon>();
         private ObservableCollection<ManagedShell.WindowsTray.NotifyIcon> promotedIcons = new ObservableCollection<ManagedShell.WindowsTray.NotifyIcon>();
+        private NotifyIconDropHandler dropHandler;
 
         public static DependencyProperty NotificationAreaProperty = DependencyProperty.Register(nameof(NotificationArea), typeof(NotificationArea), typeof(NotifyIconList), new PropertyMetadata(NotificationAreaChangedCallback));
 
@@ -41,15 +42,14 @@ namespace RetroBar.Controls
             {
                 if (Settings.Instance.CollapseNotifyIcons)
                 {
-                    NotifyIcons.ItemsSource = pinnedNotifyIconsSource.View;
+                    NotifyIcons.ItemsSource = pinnedNotifyIcons;
                     SetToggleVisibility();
                 }
                 else
                 {
                     NotifyIconToggleButton.IsChecked = false;
                     NotifyIconToggleButton.Visibility = Visibility.Collapsed;
-
-                    NotifyIcons.ItemsSource = allNotifyIconsSource.View;
+                    NotifyIcons.ItemsSource = allNotifyIcons;
                 }
             }
             else if (e.PropertyName == nameof(Settings.InvertIconsMode) || e.PropertyName == nameof(Settings.InvertNotifyIcons))
@@ -59,11 +59,11 @@ namespace RetroBar.Controls
 
                 if (Settings.Instance.CollapseNotifyIcons && NotifyIconToggleButton.IsChecked != true)
                 {
-                    NotifyIcons.ItemsSource = pinnedNotifyIconsSource.View;
+                    NotifyIcons.ItemsSource = pinnedNotifyIcons;
                 }
                 else
                 {
-                    NotifyIcons.ItemsSource = allNotifyIconsSource.View;
+                    NotifyIcons.ItemsSource = allNotifyIcons;
                 }
             }
         }
@@ -72,25 +72,19 @@ namespace RetroBar.Controls
         {
             if (!_isLoaded && NotificationArea != null)
             {
-                CompositeCollection allNotifyIcons = new CompositeCollection();
-                allNotifyIcons.Add(new CollectionContainer { Collection = NotificationArea.UnpinnedIcons });
-                allNotifyIcons.Add(new CollectionContainer { Collection = NotificationArea.PinnedIcons });
-                allNotifyIconsSource = new CollectionViewSource { Source = allNotifyIcons };
+                RefreshCollections();
+
                 NotificationArea.UnpinnedIcons.Filter = UnpinnedNotifyIcons_Filter;
 
-                CompositeCollection pinnedNotifyIcons = new CompositeCollection();
-                pinnedNotifyIcons.Add(new CollectionContainer { Collection = promotedIcons });
-                pinnedNotifyIcons.Add(new CollectionContainer { Collection = NotificationArea.PinnedIcons });
-                pinnedNotifyIconsSource = new CollectionViewSource { Source = pinnedNotifyIcons };
-
                 NotificationArea.UnpinnedIcons.CollectionChanged += UnpinnedIcons_CollectionChanged;
+                NotificationArea.PinnedIcons.CollectionChanged += PinnedIcons_CollectionChanged;
                 NotificationArea.NotificationBalloonShown += NotificationArea_NotificationBalloonShown;
 
                 Settings.Instance.PropertyChanged += Settings_PropertyChanged;
 
                 if (Settings.Instance.CollapseNotifyIcons)
                 {
-                    NotifyIcons.ItemsSource = pinnedNotifyIconsSource.View;
+                    NotifyIcons.ItemsSource = pinnedNotifyIcons;
                     SetToggleVisibility();
 
                     if (NotifyIconToggleButton.IsChecked == true)
@@ -100,7 +94,7 @@ namespace RetroBar.Controls
                 }
                 else
                 {
-                    NotifyIcons.ItemsSource = allNotifyIconsSource.View;
+                    NotifyIcons.ItemsSource = allNotifyIcons;
                 }
 
                 _isLoaded = true;
@@ -174,6 +168,10 @@ namespace RetroBar.Controls
         private void NotifyIconList_Loaded(object sender, RoutedEventArgs e)
         {
             SetNotificationAreaCollections();
+
+            // Set up drag/drop handler
+            dropHandler = new NotifyIconDropHandler(this);
+            GongSolutions.Wpf.DragDrop.DragDrop.SetDropHandler(NotifyIcons, dropHandler);
         }
 
         private void NotifyIconList_OnUnloaded(object sender, RoutedEventArgs e)
@@ -188,6 +186,7 @@ namespace RetroBar.Controls
             if (NotificationArea != null)
             {
                 NotificationArea.UnpinnedIcons.CollectionChanged -= UnpinnedIcons_CollectionChanged;
+                NotificationArea.PinnedIcons.CollectionChanged -= PinnedIcons_CollectionChanged;
                 NotificationArea.NotificationBalloonShown -= NotificationArea_NotificationBalloonShown;
             }
 
@@ -197,18 +196,55 @@ namespace RetroBar.Controls
         private void UnpinnedIcons_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
             SetToggleVisibility();
+            RefreshCollections();
+        }
+
+        private void PinnedIcons_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            RefreshCollections();
+        }
+
+        public void RefreshCollections()
+        {
+            if (NotificationArea == null) return;
+
+            // Create a list of all icons
+            var icons = NotificationArea.UnpinnedIcons.Cast<ManagedShell.WindowsTray.NotifyIcon>()
+                .Where(icon => !icon.IsPinned && !icon.IsHidden && icon.GetBehavior() != NotifyIconBehavior.Remove)
+                .Union(NotificationArea.PinnedIcons.Cast<ManagedShell.WindowsTray.NotifyIcon>())
+                .ToList();
+
+            // Sort icons according to saved order
+            var sortedIcons = icons.OrderBy(i => Settings.Instance.NotifyIconOrder?.IndexOf(i.GetInvertIdentifier()) ?? -1).ToList();
+
+            // Refresh all icons collection
+            allNotifyIcons.Clear();
+            foreach (var icon in sortedIcons)
+            {
+                allNotifyIcons.Add(icon);
+            }
+
+            // Refresh pinned icons collection
+            pinnedNotifyIcons.Clear();
+            foreach (var icon in promotedIcons)
+            {
+                pinnedNotifyIcons.Add(icon);
+            }
+            foreach (var icon in NotificationArea.PinnedIcons.Cast<ManagedShell.WindowsTray.NotifyIcon>().OrderBy(i => Settings.Instance.NotifyIconOrder?.IndexOf(i.GetInvertIdentifier()) ?? -1))
+            {
+                pinnedNotifyIcons.Add(icon);
+            }
         }
 
         private void NotifyIconToggleButton_OnClick(object sender, RoutedEventArgs e)
         {
             if (NotifyIconToggleButton.IsChecked == true)
             {
-
-                NotifyIcons.ItemsSource = allNotifyIconsSource.View;
+                NotifyIcons.ItemsSource = allNotifyIcons;
             }
             else
             {
-                NotifyIcons.ItemsSource = pinnedNotifyIconsSource.View;
+                NotifyIcons.ItemsSource = pinnedNotifyIcons;
             }
         }
 
@@ -229,6 +265,57 @@ namespace RetroBar.Controls
             {
                 NotifyIconToggleButton.Visibility = Visibility.Visible;
             }
+        }
+
+        public void SaveIconOrder()
+        {
+            if (NotificationArea == null) return;
+
+            var visibleIcons = new System.Collections.Generic.List<ManagedShell.WindowsTray.NotifyIcon>();
+
+            if (NotifyIcons.ItemsSource != null)
+            {
+                foreach (var item in NotifyIcons.ItemsSource)
+                {
+                    if (item is ManagedShell.WindowsTray.NotifyIcon icon)
+                    {
+                        if (NotifyIcons.ItemsSource == pinnedNotifyIcons && !NotificationArea.PinnedIcons.Contains(icon))
+                        {
+                            continue; // skip promoted temporary icons
+                        }
+                        visibleIcons.Add(icon);
+                    }
+                }
+            }
+
+            var oldOrder = Settings.Instance.NotifyIconOrder ?? new System.Collections.Generic.List<string>();
+            var newOrder = visibleIcons.Select(i => i.GetInvertIdentifier()).ToList();
+            var orderSet = new System.Collections.Generic.HashSet<string>(newOrder);
+
+            var result = new System.Collections.Generic.List<string>();
+            int replaceIndex = 0;
+            
+            foreach (var id in oldOrder)
+            {
+                if (orderSet.Contains(id))
+                {
+                    if (replaceIndex < newOrder.Count)
+                    {
+                        result.Add(newOrder[replaceIndex++]);
+                    }
+                }
+                else
+                {
+                    result.Add(id);
+                }
+            }
+
+            while (replaceIndex < newOrder.Count)
+            {
+                result.Add(newOrder[replaceIndex++]);
+            }
+
+            Settings.Instance.NotifyIconOrder = result;
         }
     }
 }

--- a/RetroBar/Controls/NotifyIconList.xaml.cs
+++ b/RetroBar/Controls/NotifyIconList.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -274,7 +275,7 @@ namespace RetroBar.Controls
         {
             if (NotificationArea == null) return;
 
-            var visibleIcons = new System.Collections.Generic.List<ManagedShell.WindowsTray.NotifyIcon>();
+            var visibleIcons = new List<ManagedShell.WindowsTray.NotifyIcon>();
 
             if (NotifyIcons.ItemsSource != null)
             {
@@ -291,11 +292,11 @@ namespace RetroBar.Controls
                 }
             }
 
-            var oldOrder = Settings.Instance.NotifyIconOrder ?? new System.Collections.Generic.List<string>();
+            var oldOrder = Settings.Instance.NotifyIconOrder ?? new List<string>();
             var newOrder = visibleIcons.Select(i => i.GetInvertIdentifier()).ToList();
-            var orderSet = new System.Collections.Generic.HashSet<string>(newOrder);
+            var orderSet = new HashSet<string>(newOrder);
 
-            var result = new System.Collections.Generic.List<string>();
+            var result = new List<string>();
             int replaceIndex = 0;
             
             foreach (var id in oldOrder)

--- a/RetroBar/Utilities/NotifyIconDropHandler.cs
+++ b/RetroBar/Utilities/NotifyIconDropHandler.cs
@@ -1,0 +1,48 @@
+﻿using GongSolutions.Wpf.DragDrop;
+using RetroBar.Controls;
+
+namespace RetroBar.Utilities
+{
+    public class NotifyIconDropHandler : IDropTarget
+    {
+        private NotifyIconList _notifyIconList;
+
+        public IDropInfo DropInFlight { get; set; }
+
+        public NotifyIconDropHandler(NotifyIconList notifyIconList)
+        {
+            _notifyIconList = notifyIconList;
+        }
+
+        void IDropTarget.DragOver(IDropInfo dropInfo)
+        {
+            DragDrop.DefaultDropHandler.DragOver(dropInfo);
+        }
+
+#if !NETCOREAPP3_1_OR_GREATER
+        public void DragEnter(IDropInfo dropInfo)
+        {
+            DragDrop.DefaultDropHandler.DragEnter(dropInfo);
+        }
+
+        public void DragLeave(IDropInfo dropInfo)
+        {
+            DragDrop.DefaultDropHandler.DragLeave(dropInfo);
+        }
+#endif
+
+        void IDropTarget.Drop(IDropInfo dropInfo)
+        {
+            // Save before the drop in order to catch any items not yet saved
+            _notifyIconList.SaveIconOrder();
+            DropInFlight = dropInfo;
+
+            DragDrop.DefaultDropHandler.Drop(dropInfo);
+
+            // Save post-drop state
+            _notifyIconList.SaveIconOrder();
+            _notifyIconList.RefreshCollections();
+            DropInFlight = null;
+        }
+    }
+}

--- a/RetroBar/Utilities/Settings.cs
+++ b/RetroBar/Utilities/Settings.cs
@@ -185,6 +185,13 @@ namespace RetroBar.Utilities
             set => Set(ref _notifyIconBehaviors, value);
         }
 
+        private List<string> _notifyIconOrder = new List<string>();
+        public List<string> NotifyIconOrder
+        {
+            get => _notifyIconOrder;
+            set => Set(ref _notifyIconOrder, value);
+        }
+
         private bool _allowFontSmoothing = false;
         public bool AllowFontSmoothing
         {


### PR DESCRIPTION
Saves and restores the layout order. It also changes the default behavior: it will click and activate the notification icon immediately after you release the left mouse button.

* Closes #1169
* Closes #1207
