### PR TITLE
Fix blurry text at taskbar scales above 100%

### DIFF
--- a/RetroBar/Converters/SettingsToTextFormattingModeConverter.cs
+++ b/RetroBar/Converters/SettingsToTextFormattingModeConverter.cs
@@ -11,7 +11,7 @@ namespace RetroBar.Converters
         {
             if (values[0] is double scale && values[1] is bool smoothing)
             {
-                bool disableDisplayFormatting = scale > 1 && smoothing;
+                bool disableDisplayFormatting = scale > 1;
                 return disableDisplayFormatting ? TextFormattingMode.Ideal : TextFormattingMode.Display;
             }
 


### PR DESCRIPTION
Switch TextFormattingMode to Ideal whenever TaskbarScale > 1, regardless of the AllowFontSmoothing setting. Display mode uses GDI-compatible metrics optimized for 1:1 pixel rendering; under a LayoutTransform ScaleTransform the content is rendered to an intermediate surface and upscaled with bilinear filtering, blurring even at integer scales like 200%. Ideal mode lets DirectWrite rasterize glyphs at the final physical resolution, producing crisp output at all scales.
