### PR TITLE
Fix taskbar buttons on wrong monitor after slow multi-monitor wakeup

### DIFF
--- a/RetroBar/Utilities/WindowManager.cs
+++ b/RetroBar/Utilities/WindowManager.cs
@@ -165,13 +165,15 @@ namespace RetroBar.Utilities
         {
             resetScreenCache();
 
-            if (_screenState.Count == Screen.AllScreens.Length)
+            var newScreens = AppBarScreen.FromAllScreens();
+
+            if (_screenState.Count == newScreens.Count)
             {
                 bool same = true;
-                for (int i = 0; i < Screen.AllScreens.Length; i++)
+                for (int i = 0; i < newScreens.Count; i++)
                 {
-                    Screen current = Screen.AllScreens[i];
-                    if (!(_screenState[i].Bounds == current.Bounds && _screenState[i].DeviceName == current.DeviceName && _screenState[i].Primary == current.Primary))
+                    AppBarScreen current = newScreens[i];
+                    if (!(_screenState[i].Bounds == current.Bounds && _screenState[i].DeviceName == current.DeviceName && _screenState[i].Primary == current.Primary && _screenState[i].HMonitor == current.HMonitor))
                     {
                         same = false;
                         break;


### PR DESCRIPTION
I have two monitors connected to laptop via dock and for some silly reasons the wakeup after sleep is very slow. First laptop screen turns on, then those monitors wakeup a few second later. This has been causing a weird issue.

When I login, the taskbar buttons don't appear on the same screen as the window. Most buttons gather on primary monitor, some remain on other screens. Even if I move windows to other displays, the buttons stay on wrong taskbar.

Work around I have is to open settings, then uncheck "Show on multiple displays" then check it again. That puts buttons on correct task bars.

It was bothering me a lot. I used Claude to find and fix it. And it is working fine for me.

Because I used AI, I cant say that this is the correct solution. Close the PR if it isn't. 

Blurb Claude wrote about this fix

> When a monitor wakes up slowly, Windows may assign it a new HMonitor handle while keeping bounds and device name unchanged. haveDisplaysChanged() only compared Bounds/DeviceName/Primary (using WinForms Screen objects which have no HMonitor field), so it missed such changes and skipped ReopenTaskbars(). As a result, each taskbar's Host.Screen.HMonitor stayed stale, causing Tasks_Filter to mismatch windows to the wrong taskbar even when live filtering re-evaluated.

> Fix: use AppBarScreen.FromAllScreens() (which fetches fresh HMonitors via MonitorFromPoint) instead of Screen.AllScreens, and include HMonitor in the equality check. When an HMonitor change is detected, ReopenTaskbars() is called, creating new taskbars with correct handles. 