### PR TITLE
Allow autostart to work if the Windows username contains a space.

### DIFF
--- a/RetroBar/PropertiesWindow.xaml.cs
+++ b/RetroBar/PropertiesWindow.xaml.cs
@@ -356,7 +356,8 @@ namespace RetroBar
                 }
                 else
                 {
-                    rKey?.SetValue("RetroBar", ExePath.GetExecutablePath());
+                    // Registry Run values are command lines; quote the executable path to handle spaces in usernames/paths.
+                    rKey?.SetValue("RetroBar", $"\"{ExePath.GetExecutablePath()}\"");
                 }
             }
             catch (Exception exception)


### PR DESCRIPTION
Windows kept complaining about trying to load "C:\Julien" when logging in . This was caused by lack of quoting, causing truncation of the program being started.

With this fix, the correct is shown by Autoruns64 running as administrator.

<img width="2748" height="900" alt="image" src="https://github.com/user-attachments/assets/167829cf-7e0a-4724-b9c6-887fdb58796b" />
