### PR TITLE
Refresh shell status on TaskbarCreated

### DIFF
--- a/RetroBar/Utilities/ExplorerMonitor.cs
+++ b/RetroBar/Utilities/ExplorerMonitor.cs
@@ -1,4 +1,5 @@
 using ManagedShell;
+using ManagedShell.Common.Helpers;
 using ManagedShell.Common.Logging;
 using ManagedShell.Interop;
 using System;
@@ -43,6 +44,13 @@ namespace RetroBar.Utilities
                     Dispatcher.CurrentDispatcher.BeginInvoke(() => {
                         try
                         {
+                            if (EnvironmentHelper.IsAppRunningAsShell)
+                            {
+                                // Re-evaluate shell status: some apps may delay the Shell process startup.
+                                EnvironmentHelper.IsAppRunningAsShell = NativeMethods.GetShellWindow() == IntPtr.Zero;
+                                // Trigger the hide taskbar logic again in case shell status has changed
+                                _shellManager.ExplorerHelper.HideExplorerTaskbar = true;
+                            }
                             // Reopen taskbars if explorer.exe is restarted.
                             _windowManagerRef.ReopenTaskbars();
                             // Re-initialize the tasks service to prevent leftover File Explorer windows.


### PR DESCRIPTION
Some apps such as WindowBlinds may cause delays in the Shell process. Not sure how exactly. But this can cause initial hide taskbar calls to fail, the taskbar monitor to not start, and the window work area to be incorrect, as the app will be determined to be running as shell. So we want to refresh the shell status and start the hide taskbar call again if necessary.

This fixes the issue of the default taskbar not hiding and the work area going under RetroBar on startup (when used in combination with WindowBlinds).

This is only apparent it seems when running RetroBar from Task Scheduler for faster startup. Related to: https://github.com/dremin/RetroBar/issues/440

Related change in ManagedShell to support this: https://github.com/cairoshell/ManagedShell/pull/156