### PR TITLE
Add option to smooth fonts only in right-click menus

### DIFF
--- a/RetroBar/App.xaml
+++ b/RetroBar/App.xaml
@@ -1,6 +1,7 @@
 ﻿<Application x:Class="RetroBar.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:converters="clr-namespace:RetroBar.Converters"
              ShutdownMode="OnExplicitShutdown"
              Startup="App_OnStartup"
              Exit="App_OnExit"
@@ -12,6 +13,7 @@
                 <ResourceDictionary Source="Languages/English.xaml" />
                 <ResourceDictionary Source="Themes/System.xaml" />
             </ResourceDictionary.MergedDictionaries>
+            <converters:BoolToTextRenderingModeConverter x:Key="menuTextRenderingModeConverter" />
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/RetroBar/Controls/JapaneseIme.xaml
+++ b/RetroBar/Controls/JapaneseIme.xaml
@@ -2,6 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:converters="clr-namespace:RetroBar.Converters"
+             xmlns:utilities="clr-namespace:RetroBar.Utilities"
              Loaded="UserControl_Loaded"
              Unloaded="UserControl_Unloaded">
     <Button Click="JapaneseIme_OnClick"
@@ -12,6 +13,9 @@
                    Style="{DynamicResource JapaneseIme}" />
         <Button.ContextMenu>
             <ContextMenu>
+                <TextOptions.TextRenderingMode>
+                    <Binding Source="{x:Static utilities:Settings.Instance}" Path="AllowFontSmoothingMenu" Converter="{StaticResource menuTextRenderingModeConverter}" />
+                </TextOptions.TextRenderingMode>
                 <MenuItem x:Name="JapaneseIme_full_shape_hiragana"
                       Click="JapaneseIme_full_shape_hiragana_OnClick"
                       Header="{DynamicResource ime_input_full_shape_hiragana}" />

--- a/RetroBar/Controls/ShowDesktopButton.xaml
+++ b/RetroBar/Controls/ShowDesktopButton.xaml
@@ -16,6 +16,9 @@
                Style="{DynamicResource ShowDesktopIcon}" />
         <ToggleButton.ContextMenu>
             <ContextMenu Opened="ContextMenu_Opened">
+                <TextOptions.TextRenderingMode>
+                    <Binding Source="{x:Static Settings:Settings.Instance}" Path="AllowFontSmoothingMenu" Converter="{StaticResource menuTextRenderingModeConverter}" />
+                </TextOptions.TextRenderingMode>
                 <MenuItem Style="{DynamicResource ShowDesktopItem}"
                         Name="ShowDesktopItem"
                         Click="ShowDesktop_OnClick" />

--- a/RetroBar/Controls/TaskButton.xaml
+++ b/RetroBar/Controls/TaskButton.xaml
@@ -47,6 +47,9 @@
         <Button.ContextMenu>
             <ContextMenu Opened="ContextMenu_OpenedOrClosed"
                          Closed="ContextMenu_OpenedOrClosed">
+                <TextOptions.TextRenderingMode>
+                    <Binding Source="{x:Static utilities:Settings.Instance}" Path="AllowFontSmoothingMenu" Converter="{StaticResource menuTextRenderingModeConverter}" />
+                </TextOptions.TextRenderingMode>
                 <MenuItem Header="{DynamicResource restore}"
                           Click="RestoreMenuItem_OnClick"
                           Name="RestoreMenuItem">

--- a/RetroBar/Languages/Deutsch.xaml
+++ b/RetroBar/Languages/Deutsch.xaml
@@ -24,6 +24,7 @@
     <s:String x:Key="rowcount_tip">Die Anzahl der Zeilen in der Taskleiste oben oder unten.</s:String>
     <s:String x:Key="taskbar_width">Taskleistenb_reite:</s:String>
     <s:String x:Key="allow_font_smoothing">Schriftglättung zul_assen</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Schriftglättung _in Menüs zulassen</s:String>
     <s:String x:Key="collapse_tray_icons">Infobereichsymbole ausble_nden</s:String>
     <s:String x:Key="customize">A_npassen...</s:String>
     <s:String x:Key="show_input_language">Eingabe_sprache anzeigen</s:String>

--- a/RetroBar/Languages/English.xaml
+++ b/RetroBar/Languages/English.xaml
@@ -24,6 +24,7 @@
     <s:String x:Key="rowcount_tip">The number of rows on the taskbar when on top or bottom.</s:String>
     <s:String x:Key="taskbar_width">Taskba_r width:</s:String>
     <s:String x:Key="allow_font_smoothing">_Allow font smoothing</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">_Allow font smoothing in menus</s:String>
     <s:String x:Key="collapse_tray_icons">Collapse _notification area icons</s:String>
     <s:String x:Key="customize">_Customize...</s:String>
     <s:String x:Key="show_input_language">Show the input _language</s:String>

--- a/RetroBar/Languages/Indonesia.xaml
+++ b/RetroBar/Languages/Indonesia.xaml
@@ -21,6 +21,7 @@
         <s:String>Bawah</s:String>
     </x:Array>
     <s:String x:Key="allow_font_smoothing">Izink_an penghalusan font</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Izinkan penghalusan _font di menu</s:String>
     <s:String x:Key="collapse_tray_icons">Ciutkan ikon area _notifikasi</s:String>
     <s:String x:Key="customize">S_esuaikan...</s:String>
     <s:String x:Key="show_clock">Tunjukkan jam</s:String>

--- a/RetroBar/Languages/Lëtzebuergesch.xaml
+++ b/RetroBar/Languages/Lëtzebuergesch.xaml
@@ -21,6 +21,7 @@
         <s:String>Ënnen</s:String>
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_Erlaabt Schrëftglättung</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Schrëftglättung _an de Menüen erlaben</s:String>
     <s:String x:Key="collapse_tray_icons">_Minimiséieren Notifikatiounsberäich Ikonen</s:String>
     <s:String x:Key="customize">_Personnaliséieren...</s:String>
     <s:String x:Key="show_input_language">Weist d'Input _Sprooch</s:String>

--- a/RetroBar/Languages/Malti.xaml
+++ b/RetroBar/Languages/Malti.xaml
@@ -24,6 +24,7 @@
     <s:String x:Key="rowcount_tip">In-numru ta' ringieli fuq il-bar tal-kompiti meta tkun fuq nett jew taħt nett.</s:String>
     <s:String x:Key="taskbar_width">Wisa' tal-bar tal-kompiti:</s:String>
     <s:String x:Key="allow_font_smoothing">_Ħalli l-lisjar tal-font</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Ħalli l-lisjar tal-font fil-_menù</s:String>
     <s:String x:Key="collapse_tray_icons">Ikkollassa _l-ikoni fl-area tan-notifiki</s:String>
     <s:String x:Key="customize">_Personalizza...</s:String>
     <s:String x:Key="show_input_language">Uri l-lingwa _tal-input</s:String>

--- a/RetroBar/Languages/Melayu.xaml
+++ b/RetroBar/Languages/Melayu.xaml
@@ -21,6 +21,7 @@
         <s:String>Bawah</s:String>
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_Benarkan kelicinan fon</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Benarkan _kelicinan fon dalam menu</s:String>
     <s:String x:Key="collapse_tray_icons">Jatuhkan kawasan ikon _pemberitahuan</s:String>
     <s:String x:Key="customize">Ubahsua_i...</s:String>
     <s:String x:Key="show_clock">Paparkan _jam</s:String>

--- a/RetroBar/Languages/Nederlands.xaml
+++ b/RetroBar/Languages/Nederlands.xaml
@@ -20,6 +20,7 @@
         <s:String>Onder</s:String>
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_Lettertype vloeiend maken</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">_Lettertype vloeiend maken in menu's</s:String>
     <s:String x:Key="collapse_tray_icons">_Niet-actieve pictogrammen opruimen</s:String>
     <s:String x:Key="customize">Aanpassen...</s:String>
     <s:String x:Key="show_clock">_Klok weergeven</s:String>

--- a/RetroBar/Languages/Norsk (bokmål).xaml
+++ b/RetroBar/Languages/Norsk (bokmål).xaml
@@ -24,6 +24,7 @@
     <s:String x:Key="rowcount_tip">Antall rader på oppgavelinjen når den er øverst eller nederst.</s:String>
     <s:String x:Key="taskbar_width">Oppgavelinjen_s bredde:</s:String>
     <s:String x:Key="allow_font_smoothing">_Tillat fontutjevning</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Ti_llat fontutjevning i menyer</s:String>
     <s:String x:Key="collapse_tray_icons">Skjul _ikoner i systemstatusfeltet</s:String>
     <s:String x:Key="customize">_Tilpass...</s:String>
     <s:String x:Key="show_input_language">Vis inndataspråket</s:String>

--- a/RetroBar/Languages/Suomi.xaml
+++ b/RetroBar/Languages/Suomi.xaml
@@ -30,6 +30,7 @@
         <s:Int32>5</s:Int32>
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_Salli fontin pehmennys</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Salli fontin pehmennys _valikoissa</s:String>
     <s:String x:Key="collapse_tray_icons">Piilota _ilmoitusalueen kuvakkeet</s:String>
     <s:String x:Key="customize">_Mukauta...</s:String>
     <s:String x:Key="show_input_language">Näytä syötteen _kieli</s:String>

--- a/RetroBar/Languages/Tiếng Việt.xaml
+++ b/RetroBar/Languages/Tiếng Việt.xaml
@@ -24,6 +24,7 @@
     <s:String x:Key="rowcount_tip">Số hàng trên thanh tác vụ khi ở trên cùng hoặc dưới cùng.</s:String>
     <s:String x:Key="taskbar_width">Độ dài thanh tác vụ:</s:String>
     <s:String x:Key="allow_font_smoothing">_Cho phép làm mượt phông chữ</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Cho phép làm mượt phông chữ trong _menu</s:String>
     <s:String x:Key="collapse_tray_icons">_Thu gọn các biểu tượng ở phần thông báo</s:String>
     <s:String x:Key="customize">Tùy chỉnh...</s:String>
     <s:String x:Key="show_input_language">Hiển thị _ngôn ngữ nhập liệu</s:String>

--- a/RetroBar/Languages/Türkçe.xaml
+++ b/RetroBar/Languages/Türkçe.xaml
@@ -24,6 +24,7 @@
     <s:String x:Key="rowcount_tip">Görev çubuğunun üstte veya altta olduğunda gösterilen satır sayısı.</s:String>
     <s:String x:Key="taskbar_width">Görev çubuğu genişliği:</s:String>
     <s:String x:Key="allow_font_smoothing">_Yazı tipi yumuşatmaya izin ver</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Menülerde yazı tipi yumuşatmaya _izin ver</s:String>
     <s:String x:Key="collapse_tray_icons">Bildirim _alanı simgelerini daralt</s:String>
     <s:String x:Key="customize">_Özelleştir...</s:String>
     <s:String x:Key="show_input_language">Kla_vye düzenini göster</s:String>

--- a/RetroBar/Languages/català.xaml
+++ b/RetroBar/Languages/català.xaml
@@ -24,6 +24,7 @@
     <s:String x:Key="rowcount_tip">El nombre de files a la barra de tasques quan es trobi a la part superior o inferior.</s:String>
     <s:String x:Key="taskbar_width">_Amplada de la barra de tasques:</s:String>
     <s:String x:Key="allow_font_smoothing">Permet el _suavitzat dels tipus de lletra</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Permet _el suavitzat dels tipus de lletra als menús</s:String>
     <s:String x:Key="collapse_tray_icons">Oculta les icones de _notificació</s:String>
     <s:String x:Key="customize">_Personalització...</s:String>
     <s:String x:Key="show_input_language">Mostra la _llengua d'entrada</s:String>

--- a/RetroBar/Languages/español.xaml
+++ b/RetroBar/Languages/español.xaml
@@ -24,6 +24,7 @@
     <s:String x:Key="rowcount_tip">El número de filas en la barra de tareas cuando está en la parte superior o inferior.</s:String>
     <s:String x:Key="taskbar_width">_Ancho de la barra de tareas:</s:String>
     <s:String x:Key="allow_font_smoothing">Permitir suavizado de _fuentes</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Permitir suavizado de fuentes en los _menús</s:String>
     <s:String x:Key="collapse_tray_icons">Ocultar _iconos de notificación</s:String>
     <s:String x:Key="customize">_Personalizar...</s:String>
     <s:String x:Key="show_input_language">Mostrar el idioma de _entrada</s:String>

--- a/RetroBar/Languages/euskara.xaml
+++ b/RetroBar/Languages/euskara.xaml
@@ -21,6 +21,7 @@
         <s:String>Behean</s:String>
     </x:Array>
     <s:String x:Key="allow_font_smoothing">Onartu _letra leuntzea</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">_Onartu letra leuntzea menuetan</s:String>
     <s:String x:Key="collapse_tray_icons">Ezkutatu jakinarazpen _ikonoak</s:String>
     <s:String x:Key="customize">_Personalizatu...</s:String>
     <s:String x:Key="show_clock">Erakutsi _erlojua</s:String>

--- a/RetroBar/Languages/français.xaml
+++ b/RetroBar/Languages/français.xaml
@@ -24,6 +24,7 @@
     <s:String x:Key="rowcount_tip">Le nombre de lignes de la barre des tâches quand elle est positionnée en haut ou en bas.</s:String>
     <s:String x:Key="taskbar_width">Large_ur de la barre des tâches:</s:String>
     <s:String x:Key="allow_font_smoothing">_Autoriser le lissage des polices</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Autoriser _le lissage des polices dans les menus</s:String>
     <s:String x:Key="collapse_tray_icons">_Réduire les icônes de la zone de notification</s:String>
     <s:String x:Key="customize">_Personaliser...</s:String>
     <s:String x:Key="show_input_language">Afficher l'indicateur de la langue d'_entrée</s:String>

--- a/RetroBar/Languages/hrvatski.xaml
+++ b/RetroBar/Languages/hrvatski.xaml
@@ -24,6 +24,7 @@
     <s:String x:Key="rowcount_tip">Broj redova na programskoj traci kad je na vrhu ili dnu.</s:String>
     <s:String x:Key="taskbar_width">Širina_ programske trake:</s:String>
     <s:String x:Key="allow_font_smoothing">_Dopusti izglađivanje fonta</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">_Dopusti izglađivanje fonta u izbornicima</s:String>
     <s:String x:Key="collapse_tray_icons">Sakriji neaktivne ikone</s:String>
     <s:String x:Key="customize">Prilagod_i...</s:String>
     <s:String x:Key="show_input_language">Prikaži raspored _tipkovnice</s:String>

--- a/RetroBar/Languages/italiano.xaml
+++ b/RetroBar/Languages/italiano.xaml
@@ -18,6 +18,7 @@
         <s:String>Basso</s:String>
     </x:Array>
     <s:String x:Key="allow_font_smoothing">Consenti anti-alia_sing caratteri</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Consenti anti-aliasing caratteri _nei menu</s:String>
     <s:String x:Key="collapse_tray_icons">Nascondi _icone nell'area di notifica</s:String>
     <s:String x:Key="customize">Personalizz_a...</s:String>
     <s:String x:Key="show_clock">M_ostra orologio</s:String>

--- a/RetroBar/Languages/latviešu.xaml
+++ b/RetroBar/Languages/latviešu.xaml
@@ -21,6 +21,7 @@
         <s:String>Apakšā</s:String>
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_Atļaut fontu izlīdzināšanu</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">_Atļaut fontu izlīdzināšanu izvēlnēs</s:String>
     <s:String x:Key="collapse_tray_icons">Sakļaut pazi_ņojumu apgabala ikonas</s:String>
     <s:String x:Key="customize">_Pielāgot...</s:String>
     <s:String x:Key="show_clock">Parādiet pul_ksteni</s:String>

--- a/RetroBar/Languages/lietuvių.xaml
+++ b/RetroBar/Languages/lietuvių.xaml
@@ -20,6 +20,7 @@
         <s:String>Apačioje</s:String>
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_Leisti šriftų sulyginimą</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">_Leisti šriftų sulyginimą meniu</s:String>
     <s:String x:Key="collapse_tray_icons">Sutra_ukti pranešimų srities piktogramas</s:String>
     <s:String x:Key="customize">_Tinkinti...</s:String>
     <s:String x:Key="show_clock">Rodyti lai_krodį</s:String>

--- a/RetroBar/Languages/magyar.xaml
+++ b/RetroBar/Languages/magyar.xaml
@@ -19,6 +19,7 @@
         <s:String>Lent</s:String>
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_Betűsimítás engedélyezése</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Betűsimítás _engedélyezése a menükben</s:String>
     <s:String x:Key="collapse_tray_icons">Az _értesítési terület ikonjainak összecsukása</s:String>
     <s:String x:Key="show_clock">Mutasd az _órát</s:String>
     <s:String x:Key="show_multi_mon">Megjelenítés _több kijelzőn</s:String>

--- a/RetroBar/Languages/polski.xaml
+++ b/RetroBar/Languages/polski.xaml
@@ -24,6 +24,7 @@
     <s:String x:Key="rowcount_tip">Liczba wierszy na pasku zadań, gdy jest on na górze lub na dole.</s:String>
     <s:String x:Key="taskbar_width">Szerokość paska zadań:</s:String>	
     <s:String x:Key="allow_font_smoothing">_Zezwól na wygładzanie czcionek</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Zezwól na wygładzanie czcionek w _menu</s:String>
     <s:String x:Key="collapse_tray_icons">Zwiń ikony w pasku powiadomień</s:String>
     <s:String x:Key="customize">_Dostosuj...</s:String>
     <s:String x:Key="show_input_language">Pokaż ję_zyk wprowadzania</s:String>

--- a/RetroBar/Languages/português.xaml
+++ b/RetroBar/Languages/português.xaml
@@ -24,6 +24,7 @@
     <s:String x:Key="rowcount_tip">O número de linhas na barra de tarefas quando estiver na parte superior ou inferior.</s:String>
     <s:String x:Key="taskbar_width">Lar_gura da barra de tarefas:</s:String>
     <s:String x:Key="allow_font_smoothing">Permitir s_uavização de fonte</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Permitir _suavização de fonte nos menus</s:String>
     <s:String x:Key="collapse_tray_icons">Ocultar ícones _inativos</s:String>
     <s:String x:Key="customize">_Personalizar...</s:String>
     <s:String x:Key="show_input_language">Mostrar o i_dioma de entrada</s:String>

--- a/RetroBar/Languages/română.xaml
+++ b/RetroBar/Languages/română.xaml
@@ -24,6 +24,7 @@
     <s:String x:Key="rowcount_tip">Numărul de rânduri din bara de activități când este în partea de sus sau de jos.</s:String>
     <s:String x:Key="taskbar_width">Lățime_a barei de activități:</s:String>
     <s:String x:Key="allow_font_smoothing">Activați _netezirea fontului</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Activați netezirea fontului în _meniuri</s:String>
     <s:String x:Key="collapse_tray_icons">_Ascundeți pictogramele din bara de notificări</s:String>
     <s:String x:Key="customize">_Personalizați...</s:String>
     <s:String x:Key="show_input_language">Afișați limba de _introducere</s:String>

--- a/RetroBar/Languages/slovenčina.xaml
+++ b/RetroBar/Languages/slovenčina.xaml
@@ -21,6 +21,7 @@
         <s:String>Dole</s:String>
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_Povoliť vyhladzovanie textu</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Povo_liť vyhladzovanie textu v ponukách</s:String>
     <s:String x:Key="collapse_tray_icons">Skryť upozornenia</s:String>
     <s:String x:Key="customize">_Prispôsobiť...</s:String>
     <s:String x:Key="show_clock">Zobraziť _hodiny</s:String>

--- a/RetroBar/Languages/srpski.xaml
+++ b/RetroBar/Languages/srpski.xaml
@@ -25,6 +25,7 @@
     <s:String x:Key="rowcount_tip">Broj redova na traci zadataka kada je na vrhu ili dnu.</s:String>
     <s:String x:Key="taskbar_width">Širina tra_ke zadataka:</s:String>
     <s:String x:Key="allow_font_smoothing">Dozvoli izglađivanje _fontova</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Dozvoli izglađivanje fontova u _menijima</s:String>
     <s:String x:Key="collapse_tray_icons">Skupi _ikonice u sistemskoj paleti</s:String>
     <s:String x:Key="customize">Prilago_di...</s:String>
     <s:String x:Key="show_input_language">Prikaži _jezik unosa</s:String>

--- a/RetroBar/Languages/svenska.xaml
+++ b/RetroBar/Languages/svenska.xaml
@@ -20,6 +20,7 @@
         <s:String>Nedan</s:String>
     </x:Array>
     <s:String x:Key="allow_font_smoothing">Tillåt t_ypsnittsutjämning</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Tillåt t_ypsnittsutjämning i menyer</s:String>
     <s:String x:Key="collapse_tray_icons">Kollaps meddela_ndefältet ikoner</s:String>
     <s:String x:Key="customize">Anpa_ssa...</s:String>
     <s:String x:Key="show_clock">Visa _klockan</s:String>

--- a/RetroBar/Languages/íslenska.xaml
+++ b/RetroBar/Languages/íslenska.xaml
@@ -24,6 +24,7 @@
     <s:String x:Key="rowcount_tip">Fjöldi raða á verkstikunni þegar hún er efst eða neðst.</s:String>
     <s:String x:Key="taskbar_width">Breid_d verkstikunnar:</s:String>
     <s:String x:Key="allow_font_smoothing">_Leyfa letursléttun</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">_Leyfa letursléttun í valmyndum</s:String>
     <s:String x:Key="collapse_tray_icons">Fela _táknin í tilkynningarsvæðinu</s:String>
     <s:String x:Key="customize">_Aðlaga...</s:String>
     <s:String x:Key="show_input_language">Sýna inntaksmálið</s:String>

--- a/RetroBar/Languages/čeština.xaml
+++ b/RetroBar/Languages/čeština.xaml
@@ -21,6 +21,7 @@
         <s:String>Dole</s:String>
     </x:Array>
     <s:String x:Key="allow_font_smoothing">Povolit vyhlazovaní _textu</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Povolit vyhlazování textu v _nabídkách</s:String>
     <s:String x:Key="collapse_tray_icons">Skrýt upozornění</s:String>
     <s:String x:Key="customize">_Přizspůsobit...</s:String>
     <s:String x:Key="show_clock">Zobrazit _hodiny</s:String>

--- a/RetroBar/Languages/ελληνικά.xaml
+++ b/RetroBar/Languages/ελληνικά.xaml
@@ -21,6 +21,7 @@
         <s:String>Κάτω</s:String>
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_Επιτροπή εξομάλυσης της γραμματοσειράς</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Εξομάλυνση γραμματοσειράς στα _μενού</s:String>
     <s:String x:Key="collapse_tray_icons">Απόκρ_υψη εικονιδίων περιοχής ειδοποιήσεων</s:String>
     <s:String x:Key="customize">Πρ_οσαρμογή...</s:String>
     <s:String x:Key="show_clock">Εμφάνιση του ρο_λογιού</s:String>

--- a/RetroBar/Languages/беларуская.xaml
+++ b/RetroBar/Languages/беларуская.xaml
@@ -24,6 +24,7 @@
     <s:String x:Key="rowcount_tip">Колькасьць радкоў на панэлі задач (зверху або знізу).</s:String>
     <s:String x:Key="taskbar_width">Шырыня панэлі задач:</s:String>
     <s:String x:Key="allow_font_smoothing">Дазволіць згладжванне шрыфтоў</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Дазволіць згладжванне шрыфтоў у _меню</s:String>
     <s:String x:Key="collapse_tray_icons">Згарнуць значкі вобласьці апавяшчэньняў</s:String>
     <s:String x:Key="customize">_Наладзіць...</s:String>
     <s:String x:Key="show_input_language">Паказваць раскладку клавіятуры</s:String>

--- a/RetroBar/Languages/български.xaml
+++ b/RetroBar/Languages/български.xaml
@@ -21,6 +21,7 @@
         <s:String>Отдолу</s:String>
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_Позволи изглаждането на шрифтовете</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Позволи изглаждането на шрифтовете в _менютата</s:String>
     <s:String x:Key="collapse_tray_icons">Събери и_коните в района на известията</s:String>
     <s:String x:Key="customize">Персонали_зирай...</s:String>
     <s:String x:Key="show_clock">Показвай _часовника</s:String>

--- a/RetroBar/Languages/русский.xaml
+++ b/RetroBar/Languages/русский.xaml
@@ -24,6 +24,7 @@
     <s:String x:Key="rowcount_tip">Число строк панели задач при расположении вверху или внизу.</s:String>
     <s:String x:Key="taskbar_width">_Ширина панели задач:</s:String>
     <s:String x:Key="allow_font_smoothing">Пр_именять сглаживание шрифтов</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Применять сглаживание шрифтов в _меню</s:String>
     <s:String x:Key="collapse_tray_icons">Скр_ывать неиспользуемые значки</s:String>
     <s:String x:Key="customize">_Настроить...</s:String>
     <s:String x:Key="show_input_language">Отображать раскладку _клавиатуры</s:String>

--- a/RetroBar/Languages/српски.xaml
+++ b/RetroBar/Languages/српски.xaml
@@ -25,6 +25,7 @@
     <s:String x:Key="rowcount_tip">Број редова на траци задатака када је на врху или дну.</s:String>
     <s:String x:Key="taskbar_width">Ширина тра_ке задатака:</s:String>
     <s:String x:Key="allow_font_smoothing">Дозволи изглађивање _фонтова</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Дозволи изглађивање фонтова у _менијима</s:String>
     <s:String x:Key="collapse_tray_icons">Скупи _иконице у системској палети</s:String>
     <s:String x:Key="customize">Прилаго_ди...</s:String>
     <s:String x:Key="show_input_language">Прикажи _језик уноса</s:String>

--- a/RetroBar/Languages/українська.xaml
+++ b/RetroBar/Languages/українська.xaml
@@ -24,6 +24,7 @@
     <s:String x:Key="rowcount_tip">Кількість рядків на панелі завдань (зверху або знизу).</s:String>
     <s:String x:Key="taskbar_width">Ширина панелі завдань:</s:String>
     <s:String x:Key="allow_font_smoothing">Дозволити згладжування шрифтів</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">Дозволити згладжування шрифтів у _меню</s:String>
     <s:String x:Key="collapse_tray_icons">При_ховувати невикористовувані значки</s:String>
     <s:String x:Key="customize">_Налаштувати...</s:String>
     <s:String x:Key="show_input_language">Показати мову введення</s:String>

--- a/RetroBar/Languages/עברית.xaml
+++ b/RetroBar/Languages/עברית.xaml
@@ -23,6 +23,7 @@
     <s:String x:Key="rowcount_text">מספר שורות:</s:String>
     <s:String x:Key="rowcount_tip">מספר השורות בשורת המשימות כאשר למעלה או למטה.</s:String>
     <s:String x:Key="allow_font_smoothing">_אפשר החלקת גופנים</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">אפשר החלקת גופנים ב_תפריטים</s:String>
     <s:String x:Key="collapse_tray_icons">סמלי אזור הודעה מכווץ</s:String>
     <s:String x:Key="customize">התא_מה אישית...</s:String>
     <s:String x:Key="show_clock">הצג את שעון המערכת</s:String>

--- a/RetroBar/Languages/العربية.xaml
+++ b/RetroBar/Languages/العربية.xaml
@@ -24,6 +24,7 @@
     <s:String x:Key="rowcount_tip">عدد صفوف شريط المهام عند وجوده في الأعلى أو الأسفل.</s:String>
     <s:String x:Key="taskbar_width">ع_رض شريط المهام:</s:String>
     <s:String x:Key="allow_font_smoothing">السماح بتنعيم ال_خطوط</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">السماح بتنعيم الخطوط في ال_قوائم</s:String>
     <s:String x:Key="collapse_tray_icons">طيّ أيقونات _منطقة الإعلام</s:String>
     <s:String x:Key="customize">_تخصيص...</s:String>
     <s:String x:Key="show_input_language">إظهار لغة الإد_خال</s:String>

--- a/RetroBar/Languages/فارسی.xaml
+++ b/RetroBar/Languages/فارسی.xaml
@@ -21,6 +21,7 @@
         <s:String>پایین</s:String>
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_صاف‌سازی فونت</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">صاف‌سازی فونت در _منوها</s:String>
     <s:String x:Key="collapse_tray_icons">آیکون‌ها در منطقه اعلان‌ها جمع شوند</s:String>
     <s:String x:Key="customize">سفارشی‌سازی</s:String>
     <s:String x:Key="show_clock">نمایش ساعت</s:String>

--- a/RetroBar/Languages/ไทย.xaml
+++ b/RetroBar/Languages/ไทย.xaml
@@ -21,6 +21,7 @@
         <s:String>ล่าง</s:String>
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_ใช้การปรับตัวอักษรให้คมชัด</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">_ใช้การปรับตัวอักษรให้คมชัดในเมนู</s:String>
     <s:String x:Key="collapse_tray_icons">ยุบไอคอนใน_พื้นที่แจ้งเตือน</s:String>
     <s:String x:Key="customize">_ปรับแต่ง...</s:String>
     <s:String x:Key="show_clock">แสดง_นาฬิกา</s:String>

--- a/RetroBar/Languages/中文(简体).xaml
+++ b/RetroBar/Languages/中文(简体).xaml
@@ -24,6 +24,7 @@
     <s:String x:Key="rowcount_tip">任务栏位于顶部或底部时的行数。</s:String>
     <s:String x:Key="taskbar_width">任务栏宽度(_W): </s:String>
     <s:String x:Key="allow_font_smoothing">允许字体平滑(_A)</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">允许菜单中的字体平滑(_A)</s:String>
     <s:String x:Key="collapse_tray_icons">收起通知区域图标(_N)</s:String>
     <s:String x:Key="customize">自定义(_C)...</s:String>
     <s:String x:Key="show_input_language">显示输入语言(_L)</s:String>

--- a/RetroBar/Languages/中文(繁體).xaml
+++ b/RetroBar/Languages/中文(繁體).xaml
@@ -21,6 +21,7 @@
         <s:String>下</s:String>
     </x:Array>
     <s:String x:Key="allow_font_smoothing">允許字體平滑(_A)</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">允許選單中的字體平滑(_A)</s:String>
     <s:String x:Key="collapse_tray_icons">隱藏非使用中時圖示(_N)</s:String>
     <s:String x:Key="customize">自訂(_E)...</s:String>
     <s:String x:Key="show_input_language">顯示語言列</s:String>

--- a/RetroBar/Languages/日本語.xaml
+++ b/RetroBar/Languages/日本語.xaml
@@ -24,6 +24,7 @@
     <s:String x:Key="rowcount_tip">タスクバーが上または下に配置されている場合のタスクバーの行数。</s:String>
     <s:String x:Key="taskbar_width">タスクバーの幅(_W)：</s:String>
     <s:String x:Key="allow_font_smoothing">フォントをなめらかにする(_A)</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">メニューのフォントをなめらかにする(_A)</s:String>
     <s:String x:Key="collapse_tray_icons">通知領域のアイコンを折りたたむ(_N)</s:String>
     <s:String x:Key="customize">カスタマイズ(_C)...</s:String>
     <s:String x:Key="show_input_language">表示入力言語(_L)</s:String>

--- a/RetroBar/Languages/한국어.xaml
+++ b/RetroBar/Languages/한국어.xaml
@@ -21,6 +21,7 @@
         <s:String>하단</s:String>
     </x:Array>
     <s:String x:Key="allow_font_smoothing">폰트 스무딩 활성화(_S)</s:String>
+    <s:String x:Key="allow_font_smoothing_menu">메뉴에서 폰트 스무딩 활성화(_A)</s:String>
     <s:String x:Key="collapse_tray_icons">사용하지 않은 아이콘 숨기기(_H)</s:String>
     <s:String x:Key="customize">사용자 지정(_C)...</s:String>
     <s:String x:Key="show_clock">시계 표시(_K)</s:String>

--- a/RetroBar/PropertiesWindow.xaml
+++ b/RetroBar/PropertiesWindow.xaml
@@ -376,6 +376,10 @@
                                   IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowEndTaskButton, UpdateSourceTrigger=PropertyChanged}">
                             <Label Content="{DynamicResource show_end_task_button}" />
                         </CheckBox>
+                        <CheckBox x:Name="cbAllowFontSmoothingMenu"
+                                  IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=AllowFontSmoothingMenu, UpdateSourceTrigger=PropertyChanged}">
+                            <Label Content="{DynamicResource allow_font_smoothing_menu}" />
+                        </CheckBox>
                         <DockPanel>
                             <Label VerticalAlignment="Center"
                                    Target="{Binding ElementName=cboWinNumHotkeysAction}">

--- a/RetroBar/Taskbar.xaml
+++ b/RetroBar/Taskbar.xaml
@@ -88,6 +88,9 @@
             <GroupBox Style="{DynamicResource Tray}">
                 <GroupBox.ContextMenu>
                     <ContextMenu>
+                        <TextOptions.TextRenderingMode>
+                            <Binding Source="{x:Static utilities:Settings.Instance}" Path="AllowFontSmoothingMenu" Converter="{StaticResource menuTextRenderingModeConverter}" />
+                        </TextOptions.TextRenderingMode>
                         <!--StaticResourceExtension ResourceKey="ToolbarsItem" />
                         <Separator /-->
                         <StaticResourceExtension ResourceKey="SetTimeMenuItem" />
@@ -132,6 +135,9 @@
     </ContentControl>
     <appbar:AppBarWindow.ContextMenu>
         <ContextMenu Opened="ContextMenu_Opened">
+            <TextOptions.TextRenderingMode>
+                <Binding Source="{x:Static utilities:Settings.Instance}" Path="AllowFontSmoothingMenu" Converter="{StaticResource menuTextRenderingModeConverter}" />
+            </TextOptions.TextRenderingMode>
             <!-- TODO: Add when desk bands and additional taskbars are supported. -->
             <!--StaticResourceExtension ResourceKey="ToolbarsItem" />
             <Separator /-->

--- a/RetroBar/Themes/System.xaml
+++ b/RetroBar/Themes/System.xaml
@@ -65,6 +65,11 @@
     <Style TargetType="ContextMenu"
            x:Key="{x:Type ContextMenu}"
            BasedOn="{StaticResource GlobalFonts}">
+        <!-- Menus are never scaled, so keep their text on the pixel grid (Display). Otherwise
+             they'd inherit the taskbar's Ideal formatting when font smoothing is on while scaled,
+             which would smooth menu text regardless of the menu's own smoothing setting. -->
+        <Setter Property="TextOptions.TextFormattingMode"
+                Value="Display" />
     </Style>
 
     <Style TargetType="ToolTip"

--- a/RetroBar/Utilities/Settings.cs
+++ b/RetroBar/Utilities/Settings.cs
@@ -192,6 +192,13 @@ namespace RetroBar.Utilities
             set => Set(ref _allowFontSmoothing, value);
         }
 
+        private bool _allowFontSmoothingMenu = true;
+        public bool AllowFontSmoothingMenu
+        {
+            get => _allowFontSmoothingMenu;
+            set => Set(ref _allowFontSmoothingMenu, value);
+        }
+
         private bool _useSoftwareRendering = false;
         public bool UseSoftwareRendering
         {


### PR DESCRIPTION
Introduce an AllowFontSmoothingMenu setting so the right-click menus can use smooth (anti-aliased) text independently of the taskbar itself. Menu text is smoothed when either AllowFontSmoothing or AllowFontSmoothingMenu is enabled, preserving the existing behavior of the global setting.

The setting is applied via a new MenuFontSmoothingToTextRenderingModeConverter bound on every context menu (taskbar, tray, task buttons, show desktop, and the Japanese IME menu). A new checkbox is added to the taskbar properties, disabled while global font smoothing is on. Translations for the new string are added to all language files.

---

This makes the menu more readable for now until I figure out a couple of things.

I'm working on a couple more improvements. I hope this is fine if I open up a couple more merge requests like this one.