### PR TITLE
Crisp scaled taskbar text

### DIFF
--- a/RetroBar/Controls/Clock.xaml.cs
+++ b/RetroBar/Controls/Clock.xaml.cs
@@ -58,6 +58,16 @@ namespace RetroBar.Controls
             Settings.Instance.PropertyChanged += Settings_PropertyChanged;
             SystemEvents.TimeChanged += TimeChanged;
             SystemEvents.UserPreferenceChanged += UserPreferenceChanged;
+
+            UpdateTextScaling();
+        }
+
+        private void UpdateTextScaling()
+        {
+            // Only scale within the actual taskbar; the properties window preview hosts this
+            // same control without the taskbar's ScaleTransform, so it should stay unscaled.
+            double scale = Window.GetWindow(this) is RetroBar.Taskbar ? Settings.Instance.TaskbarScale : 1.0;
+            TextScaler.ApplyScaling(this, scale);
         }
 
         private void StartClock()
@@ -92,6 +102,16 @@ namespace RetroBar.Controls
             else if (e.PropertyName == nameof(Settings.ShowClockSeconds))
             {
                 UpdateUserCulture();
+            }
+            else if (e.PropertyName == nameof(Settings.TaskbarScale))
+            {
+                UpdateTextScaling();
+            }
+            else if (e.PropertyName == nameof(Settings.Theme))
+            {
+                // The clock template (and its base font size) is swapped on theme change;
+                // re-apply once that has happened.
+                Dispatcher.BeginInvoke(new Action(UpdateTextScaling), DispatcherPriority.Loaded);
             }
         }
 

--- a/RetroBar/Controls/InputLanguage.xaml
+++ b/RetroBar/Controls/InputLanguage.xaml
@@ -22,10 +22,13 @@
         </Thumb>
         <WrapPanel x:Name="InputLanguageDockPanel"
                    Style="{DynamicResource LanguageBar}">
-            <TextBlock x:Name="InputLanguageText"
-                   Style="{DynamicResource InputLanguage}"
-                   Text="{Binding Path=LocaleIdentifier, Converter={StaticResource cultureInfoToLocaleNameConverter}, ConverterParameter=TwoLetterIsoLanguageName, Mode=OneWay}">
-            </TextBlock>
+            <Border x:Name="InputLanguageBox"
+                    Style="{DynamicResource InputLanguageBox}">
+                <TextBlock x:Name="InputLanguageText"
+                       Style="{DynamicResource InputLanguage}"
+                       Text="{Binding Path=LocaleIdentifier, Converter={StaticResource cultureInfoToLocaleNameConverter}, ConverterParameter=TwoLetterIsoLanguageName, Mode=OneWay}">
+                </TextBlock>
+            </Border>
         </WrapPanel>
     </DockPanel>
 

--- a/RetroBar/Controls/InputLanguage.xaml.cs
+++ b/RetroBar/Controls/InputLanguage.xaml.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 using System.Windows.Threading;
 using ManagedShell.Common.Helpers;
 using ManagedShell.Common.Logging;
@@ -46,6 +47,46 @@ namespace RetroBar.Controls
             }
 
             Settings.Instance.PropertyChanged += Settings_PropertyChanged;
+
+            UpdateTextScaling();
+        }
+
+        // The unscaled box size from the InputLanguageBox style, captured once so the scaling
+        // doesn't hard-code it.
+        private double _baseBoxHeight = double.NaN;
+        private double _baseBoxMinWidth = double.NaN;
+
+        private void UpdateTextScaling()
+        {
+            // Only scale within the actual taskbar; the properties window preview hosts this
+            // same control without the taskbar's ScaleTransform, so it should stay unscaled.
+            double scale = Window.GetWindow(this) is RetroBar.Taskbar ? Settings.Instance.TaskbarScale : 1.0;
+
+            if (double.IsNaN(_baseBoxHeight))
+            {
+                _baseBoxHeight = InputLanguageBox.Height;
+                _baseBoxMinWidth = InputLanguageBox.MinWidth;
+            }
+
+            // Render the whole indicator at real, pixel-aligned sizes with a 1/scale
+            // counter-transform, so both the box and the text stay crisp (no fractional-pixel
+            // blur) and the text centers in real-pixel space rather than in the taskbar's
+            // fractional scaled space. The base font size comes from the current theme's
+            // GlobalFontSize.
+            if (scale > 1.0 && Application.Current.TryFindResource("GlobalFontSize") is double baseFontSize)
+            {
+                InputLanguageBox.LayoutTransform = new ScaleTransform(1.0 / scale, 1.0 / scale);
+                InputLanguageBox.Height = Math.Round(_baseBoxHeight * scale);
+                InputLanguageBox.MinWidth = Math.Round(_baseBoxMinWidth * scale);
+                InputLanguageText.FontSize = Math.Round(baseFontSize * scale);
+            }
+            else
+            {
+                InputLanguageBox.LayoutTransform = null;
+                InputLanguageBox.ClearValue(FrameworkElement.HeightProperty);
+                InputLanguageBox.ClearValue(FrameworkElement.MinWidthProperty);
+                InputLanguageText.ClearValue(TextBlock.FontSizeProperty);
+            }
         }
 
         private void SetLocaleIdentifier()
@@ -122,17 +163,17 @@ namespace RetroBar.Controls
 
                 if (InstalledLanguagesCount() == 1)
                 {
-                    InputLanguageText.Visibility = Visibility.Collapsed;
+                    InputLanguageBox.Visibility = Visibility.Collapsed;
                 }
                 else
                 {
-                    InputLanguageText.Visibility = Visibility.Visible;
+                    InputLanguageBox.Visibility = Visibility.Visible;
                 }
             }
             else
             {
                 JapaneseImeRemove();
-                InputLanguageText.Visibility = Visibility.Visible;
+                InputLanguageBox.Visibility = Visibility.Visible;
             }
         }
 
@@ -155,6 +196,15 @@ namespace RetroBar.Controls
                 {
                     StopWatch();
                 }
+            }
+            else if (e.PropertyName == nameof(Settings.TaskbarScale))
+            {
+                UpdateTextScaling();
+            }
+            else if (e.PropertyName == nameof(Settings.Theme))
+            {
+                // The base font size can change with the theme; re-apply once it has loaded.
+                Dispatcher.BeginInvoke(new Action(UpdateTextScaling), DispatcherPriority.Loaded);
             }
         }
 

--- a/RetroBar/Controls/TaskButton.xaml.cs
+++ b/RetroBar/Controls/TaskButton.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media.Animation;
+using System.Windows.Threading;
 using ManagedShell.Common.Helpers;
 using ManagedShell.Interop;
 using ManagedShell.WindowsTasks;
@@ -83,6 +84,15 @@ namespace RetroBar.Controls
             storyboard.Begin();
         }
 
+        private void UpdateTextScaling()
+        {
+            // Only scale within the actual taskbar; the properties window preview uses its own
+            // markup (not this control), so this never runs unscaled, but the guard keeps it
+            // consistent with the clock and input language indicator.
+            double scale = System.Windows.Window.GetWindow(this) is RetroBar.Taskbar ? Settings.Instance.TaskbarScale : 1.0;
+            TextScaler.ApplyScaling(this, scale);
+        }
+
         private void TaskButton_OnLoaded(object sender, RoutedEventArgs e)
         {
             Window = DataContext as ApplicationWindow;
@@ -104,6 +114,8 @@ namespace RetroBar.Controls
             {
                 Animate();
             }
+
+            UpdateTextScaling();
 
             _isLoaded = true;
         }
@@ -285,6 +297,12 @@ namespace RetroBar.Controls
             if (e.PropertyName == nameof(Settings.Theme))
             {
                 SetStyle();
+                // The base font size can change with the theme; re-apply once it has loaded.
+                Dispatcher.BeginInvoke(new Action(UpdateTextScaling), DispatcherPriority.Loaded);
+            }
+            else if (e.PropertyName == nameof(Settings.TaskbarScale))
+            {
+                UpdateTextScaling();
             }
         }
 

--- a/RetroBar/Themes/System.xaml
+++ b/RetroBar/Themes/System.xaml
@@ -910,20 +910,30 @@
         </Style.Triggers>
     </Style>
 
+    <Style TargetType="Border"
+           x:Key="InputLanguageBox">
+        <Setter Property="Background"
+                Value="{DynamicResource InputLanguageBackground}"/>
+        <Setter Property="MinWidth"
+                Value="16"/>
+        <Setter Property="Height"
+                Value="16"/>
+        <!-- Hard pixel edges so the box stays crisp even when scaling places it on a
+             fractional device pixel (a solid rectangle otherwise anti-aliases its edges). -->
+        <Setter Property="RenderOptions.EdgeMode"
+                Value="Aliased"/>
+    </Style>
+
     <Style TargetType="TextBlock"
            x:Key="InputLanguage"
            BasedOn="{StaticResource GlobalFonts}">
         <Setter Property="Foreground"
                 Value="{DynamicResource InputLanguageForeground}" />
-        <Setter Property="Background" 
-                Value="{DynamicResource InputLanguageBackground}"/>
-        <Setter Property="MinWidth" 
-                Value="16"/>
-        <Setter Property="Height"
-                Value="16"/>
-        <Setter Property="Padding"
-                Value="0,1,0,0" />
         <Setter Property="TextAlignment"
+                Value="Center" />
+        <Setter Property="HorizontalAlignment"
+                Value="Center" />
+        <Setter Property="VerticalAlignment"
                 Value="Center" />
     </Style>
 

--- a/RetroBar/Themes/Windows Vista Aero.xaml
+++ b/RetroBar/Themes/Windows Vista Aero.xaml
@@ -1436,9 +1436,9 @@
         </Style.Triggers>
     </Style>
 
-    <Style TargetType="TextBlock"
-           x:Key="InputLanguage"
-           BasedOn="{StaticResource InputLanguage}">
+    <Style TargetType="Border"
+           x:Key="InputLanguageBox"
+           BasedOn="{StaticResource InputLanguageBox}">
         <Setter Property="Margin"
                 Value="0,6,0,0" />
         <Setter Property="HorizontalAlignment"

--- a/RetroBar/Utilities/TextScaler.cs
+++ b/RetroBar/Utilities/TextScaler.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace RetroBar.Utilities
+{
+    // Renders the TextBlocks within a control at a real, pixel-aligned font size when the
+    // taskbar is scaled, instead of letting the taskbar's ScaleTransform stretch text that
+    // was laid out at its base size (which pushes glyphs off the pixel grid and looks blurry).
+    //
+    // Each TextBlock gets FontSize = round(baseFontSize * scale) and a 1/scale counter-transform,
+    // so its glyphs render with a net identity transform (crisp) while it still occupies the
+    // scaled layout slot. The base size is read back from the element each call (after clearing
+    // our previous override), so repeated calls don't compound and the base stays correct when
+    // the theme changes it.
+    public static class TextScaler
+    {
+        public static void ApplyScaling(DependencyObject root, double scale)
+        {
+            if (root == null)
+            {
+                return;
+            }
+
+            int count = VisualTreeHelper.GetChildrenCount(root);
+
+            for (int i = 0; i < count; i++)
+            {
+                DependencyObject child = VisualTreeHelper.GetChild(root, i);
+
+                if (child is TextBlock textBlock)
+                {
+                    // Drop our previous override so FontSize reverts to the (theme) base size.
+                    textBlock.ClearValue(TextBlock.FontSizeProperty);
+
+                    if (scale > 1.0)
+                    {
+                        textBlock.FontSize = Math.Round(textBlock.FontSize * scale);
+                        textBlock.LayoutTransform = new ScaleTransform(1.0 / scale, 1.0 / scale);
+                    }
+                    else
+                    {
+                        textBlock.ClearValue(FrameworkElement.LayoutTransformProperty);
+                    }
+                }
+
+                ApplyScaling(child, scale);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR contains a commit of https://github.com/dremin/RetroBar/pull/1401, so it should be gone as soon as the other PR is merged hopefully.

## Summary

RetroBar scales the taskbar with a single `ScaleTransform`. At fractional scales
(125%, 150%, 175%, …) that stretches text which was laid out at its base size,
pushing glyphs off the pixel grid so they look blurry. This PR renders the
taskbar's text at a real, pixel-aligned size instead, keeping it crisp at any
scale while leaving the 100%/200% (whole-number) appearance unchanged.

## What changed

- **Task button labels** - rendered at `round(fontSize × scale)` with a `1/scale`
  counter-transform, so the glyphs land on the pixel grid (net identity transform)
  while the label still fills its scaled slot.
- **Clock** - same treatment via a small shared `TextScaler` helper that walks the
  control's text and scales each `TextBlock`. Applied only inside the taskbar, not
  the Properties-window preview.
- **Input language indicator** - restructured so the text is centered by layout
  inside a box that is itself rendered at real pixel sizes with aliased edges, so
  the indicator stays crisp and consistently centered at every scale instead of
  drifting with per-scale rounding.

## Behavior preserved

- 100% and integer scales render exactly as before.
- The Properties-window previews are unaffected (they aren't scaled - detected via
  the host window type).
- Theme-aware: base font size is read from `GlobalFontSize`, so the 12px themes
  (Vista/Longhorn Aero) scale correctly. The Vista Aero positioning override was
  moved onto the new indicator box.
- Vertical (left/right edge) taskbars are unchanged.

## Testing

Built for `net6.0-windows`. Manually verified at 100 / 125 / 150 / 175 / 200%:
task labels, clock, and the language indicator are crisp and centered; the
Properties previews and vertical taskbars look normal.

## Related issue

Partially addresses [#1213](https://github.com/dremin/RetroBar/issues/1213): it covers the **text** half, crisp, pixel-aligned text (aliased when font smoothing is off) at every scale, not just 200%. **Icons** are still transform-scaled and remain a follow-up.