### PR TITLE
Distribute leftover width across task buttons to fill the row

### DIFF
--- a/RetroBar/Controls/TaskList.xaml
+++ b/RetroBar/Controls/TaskList.xaml
@@ -11,6 +11,7 @@
         <ResourceDictionary>
             <converters:DockOrientationConverter x:Key="dockOrientationConverter" />
             <converters:EdgeOrientationConverter x:Key="orientationConverter" />
+            <converters:TaskButtonWidthConverter x:Key="taskButtonWidthConverter" />
         </ResourceDictionary>
     </UserControl.Resources>
     <DockPanel>
@@ -46,8 +47,16 @@
                 </ItemsControl.ItemsPanel>
                 <ItemsControl.ItemTemplate>
                     <ItemContainerTemplate>
-                        <local:TaskButton Width="{Binding Path=ButtonWidth, RelativeSource={RelativeSource FindAncestor, AncestorType=local:TaskList}}"
-                                          Host="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=local:TaskList}}"></local:TaskButton>
+                        <local:TaskButton Host="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=local:TaskList}}">
+                            <local:TaskButton.Width>
+                                <MultiBinding Converter="{StaticResource taskButtonWidthConverter}">
+                                    <Binding Path="(ItemsControl.AlternationIndex)" RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=ContentPresenter}" />
+                                    <Binding Path="ButtonWidth" RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=local:TaskList}" />
+                                    <Binding Path="ExtraWidthCount" RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=local:TaskList}" />
+                                    <Binding Path="ButtonsPerRow" RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=local:TaskList}" />
+                                </MultiBinding>
+                            </local:TaskButton.Width>
+                        </local:TaskButton>
                     </ItemContainerTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>

--- a/RetroBar/Controls/TaskList.xaml.cs
+++ b/RetroBar/Controls/TaskList.xaml.cs
@@ -30,6 +30,24 @@ namespace RetroBar.Controls
             set { SetValue(ButtonWidthProperty, value); }
         }
 
+        public static DependencyProperty ButtonsPerRowProperty = DependencyProperty.Register(nameof(ButtonsPerRow), typeof(int), typeof(TaskList), new PropertyMetadata(0));
+
+        public int ButtonsPerRow
+        {
+            get { return (int)GetValue(ButtonsPerRowProperty); }
+            set { SetValue(ButtonsPerRowProperty, value); }
+        }
+
+        // Number of columns in a full row that get one extra pixel, so the row fills the
+        // taskbar exactly instead of leaving the floored remainder empty.
+        public static DependencyProperty ExtraWidthCountProperty = DependencyProperty.Register(nameof(ExtraWidthCount), typeof(int), typeof(TaskList), new PropertyMetadata(0));
+
+        public int ExtraWidthCount
+        {
+            get { return (int)GetValue(ExtraWidthCountProperty); }
+            set { SetValue(ExtraWidthCountProperty, value); }
+        }
+
         public static DependencyProperty TasksProperty = DependencyProperty.Register(nameof(Tasks), typeof(Tasks), typeof(TaskList), new PropertyMetadata(TasksChangedCallback));
 
         public Tasks Tasks
@@ -223,6 +241,7 @@ namespace RetroBar.Controls
 
             if (Settings.Instance.Edge == AppBarEdge.Left || Settings.Instance.Edge == AppBarEdge.Right)
             {
+                ExtraWidthCount = 0;
                 ButtonWidth = ActualWidth;
                 SetScrollable(true); // while technically not always scrollable, we don't run into DPI-specific issues with it enabled while vertical
                 return;
@@ -232,24 +251,34 @@ namespace RetroBar.Controls
             int rows = Host.Rows;
 
             int taskCount = TasksList.Items.Count;
+            TasksList.AlternationCount = taskCount; // keep in sync for correct AlternationIndex
+
             double margin = TaskButtonLeftMargin + TaskButtonRightMargin;
-            double maxWidth = TasksList.ActualWidth / Math.Ceiling((double)taskCount / rows);
+            ButtonsPerRow = Math.Max(1, (int)Math.Ceiling((double)taskCount / rows));
+            double maxWidth = TasksList.ActualWidth / ButtonsPerRow;
             double defaultWidth = DefaultButtonWidth + margin;
             double minWidth = MinButtonWidth + margin;
 
             if (maxWidth > defaultWidth)
             {
+                // Room to spare: keep the default width and leave the trailing gap.
+                ExtraWidthCount = 0;
                 ButtonWidth = defaultWidth;
                 SetScrollable(false);
             }
             else if (maxWidth < minWidth)
             {
+                ExtraWidthCount = 0;
                 ButtonWidth = Math.Ceiling(defaultWidth / 2);
                 SetScrollable(true);
             }
             else
             {
-                ButtonWidth = Math.Floor(maxWidth);
+                // Buttons are shrunk to fit a full row: spread the pixels lost to flooring
+                // across the columns so the row fills the taskbar.
+                double baseWidth = Math.Floor(maxWidth);
+                ButtonWidth = baseWidth;
+                ExtraWidthCount = (int)Math.Floor(TasksList.ActualWidth) - (int)baseWidth * ButtonsPerRow;
                 SetScrollable(false);
             }
         }

--- a/RetroBar/Converters/TaskButtonWidthConverter.cs
+++ b/RetroBar/Converters/TaskButtonWidthConverter.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Windows.Data;
+
+namespace RetroBar.Converters
+{
+    // Computes an individual task button width so a full row fills the taskbar exactly.
+    // Every button gets the base (floored) width; the pixels lost to flooring are spread
+    // evenly across the row's columns, each affected column getting one extra pixel.
+    //
+    // Distribution is keyed on the column (index % buttonsPerRow) so widths line up in
+    // columns across rows, and a partial last row keeps the same per-column widths.
+    //
+    // values[0] = item index (ItemsControl.AlternationIndex)
+    // values[1] = base button width (double)
+    // values[2] = number of columns that get an extra pixel (int)
+    // values[3] = buttons per row (int)
+    //
+    // If the index isn't available the base width is returned, so the layout simply falls
+    // back to uniform widths rather than breaking.
+    public class TaskButtonWidthConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (values.Length < 4 || !(values[1] is double baseWidth))
+            {
+                return Binding.DoNothing;
+            }
+
+            if (values[0] is int index
+                && values[2] is int extraCount
+                && values[3] is int buttonsPerRow
+                && extraCount > 0
+                && buttonsPerRow > 0)
+            {
+                int column = index % buttonsPerRow;
+
+                // Evenly spaced "+1"s: 1 when this column falls on a distribution boundary.
+                int extraForColumn = (column + 1) * extraCount / buttonsPerRow - column * extraCount / buttonsPerRow;
+
+                return baseWidth + extraForColumn;
+            }
+
+            return baseWidth;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}


### PR DESCRIPTION
Fixes [#139](https://github.com/dremin/RetroBar/issues/139).

When task buttons are shrunk to fit a full row, the per-button width was floored
and applied uniformly, leaving the remainder empty as a gap before the tray.

This spreads those leftover pixels back across the row: each button's width is
based on its column (`index % buttonsPerRow`), with one extra pixel handed to
evenly-spaced columns, so a full row fills the taskbar, widths differ by at most
1px, and they stay aligned in columns across rows (the "scattered" distribution
the issue suggested).

Only the shrink-to-fit case changes, when there's room to spare the default width
is kept, and the min-width/scroll case is unchanged.