### PR TITLE
Add crisp start button icon rendering option

### DIFF
--- a/RetroBar/Languages/Deutsch.xaml
+++ b/RetroBar/Languages/Deutsch.xaml
@@ -25,6 +25,7 @@
     <s:String x:Key="taskbar_width">Taskleistenb_reite:</s:String>
     <s:String x:Key="allow_font_smoothing">Schriftglättung zul_assen</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Schriftglättung _in Menüs zulassen</s:String>
+    <s:String x:Key="crisp_start_button_icon">Sc_harfes Symbol für die Startschaltfläche</s:String>
     <s:String x:Key="collapse_tray_icons">Infobereichsymbole ausble_nden</s:String>
     <s:String x:Key="customize">A_npassen...</s:String>
     <s:String x:Key="show_input_language">Eingabe_sprache anzeigen</s:String>

--- a/RetroBar/Languages/English.xaml
+++ b/RetroBar/Languages/English.xaml
@@ -25,6 +25,7 @@
     <s:String x:Key="taskbar_width">Taskba_r width:</s:String>
     <s:String x:Key="allow_font_smoothing">_Allow font smoothing</s:String>
     <s:String x:Key="allow_font_smoothing_menu">_Allow font smoothing in menus</s:String>
+    <s:String x:Key="crisp_start_button_icon">Crisp start _button icon</s:String>
     <s:String x:Key="collapse_tray_icons">Collapse _notification area icons</s:String>
     <s:String x:Key="customize">_Customize...</s:String>
     <s:String x:Key="show_input_language">Show the input _language</s:String>

--- a/RetroBar/Languages/Indonesia.xaml
+++ b/RetroBar/Languages/Indonesia.xaml
@@ -22,6 +22,7 @@
     </x:Array>
     <s:String x:Key="allow_font_smoothing">Izink_an penghalusan font</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Izinkan penghalusan _font di menu</s:String>
+    <s:String x:Key="crisp_start_button_icon">_Ikon tombol Mulai yang tajam</s:String>
     <s:String x:Key="collapse_tray_icons">Ciutkan ikon area _notifikasi</s:String>
     <s:String x:Key="customize">S_esuaikan...</s:String>
     <s:String x:Key="show_clock">Tunjukkan jam</s:String>

--- a/RetroBar/Languages/Lëtzebuergesch.xaml
+++ b/RetroBar/Languages/Lëtzebuergesch.xaml
@@ -22,6 +22,7 @@
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_Erlaabt Schrëftglättung</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Schrëftglättung _an de Menüen erlaben</s:String>
+    <s:String x:Key="crisp_start_button_icon">_Kloer Start-Knäppchen-Ikon</s:String>
     <s:String x:Key="collapse_tray_icons">_Minimiséieren Notifikatiounsberäich Ikonen</s:String>
     <s:String x:Key="customize">_Personnaliséieren...</s:String>
     <s:String x:Key="show_input_language">Weist d'Input _Sprooch</s:String>

--- a/RetroBar/Languages/Malti.xaml
+++ b/RetroBar/Languages/Malti.xaml
@@ -25,6 +25,7 @@
     <s:String x:Key="taskbar_width">Wisa' tal-bar tal-kompiti:</s:String>
     <s:String x:Key="allow_font_smoothing">_Ħalli l-lisjar tal-font</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Ħalli l-lisjar tal-font fil-_menù</s:String>
+    <s:String x:Key="crisp_start_button_icon">I_kona ċara tal-buttuna Ibda</s:String>
     <s:String x:Key="collapse_tray_icons">Ikkollassa _l-ikoni fl-area tan-notifiki</s:String>
     <s:String x:Key="customize">_Personalizza...</s:String>
     <s:String x:Key="show_input_language">Uri l-lingwa _tal-input</s:String>

--- a/RetroBar/Languages/Melayu.xaml
+++ b/RetroBar/Languages/Melayu.xaml
@@ -22,6 +22,7 @@
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_Benarkan kelicinan fon</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Benarkan _kelicinan fon dalam menu</s:String>
+    <s:String x:Key="crisp_start_button_icon">Ikon butang _Mula yang tajam</s:String>
     <s:String x:Key="collapse_tray_icons">Jatuhkan kawasan ikon _pemberitahuan</s:String>
     <s:String x:Key="customize">Ubahsua_i...</s:String>
     <s:String x:Key="show_clock">Paparkan _jam</s:String>

--- a/RetroBar/Languages/Nederlands.xaml
+++ b/RetroBar/Languages/Nederlands.xaml
@@ -21,6 +21,7 @@
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_Lettertype vloeiend maken</s:String>
     <s:String x:Key="allow_font_smoothing_menu">_Lettertype vloeiend maken in menu's</s:String>
+    <s:String x:Key="crisp_start_button_icon">_Scherp startknoppictogram</s:String>
     <s:String x:Key="collapse_tray_icons">_Niet-actieve pictogrammen opruimen</s:String>
     <s:String x:Key="customize">Aanpassen...</s:String>
     <s:String x:Key="show_clock">_Klok weergeven</s:String>

--- a/RetroBar/Languages/Norsk (bokmål).xaml
+++ b/RetroBar/Languages/Norsk (bokmål).xaml
@@ -25,6 +25,7 @@
     <s:String x:Key="taskbar_width">Oppgavelinjen_s bredde:</s:String>
     <s:String x:Key="allow_font_smoothing">_Tillat fontutjevning</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Ti_llat fontutjevning i menyer</s:String>
+    <s:String x:Key="crisp_start_button_icon">_Skarpt startknappikon</s:String>
     <s:String x:Key="collapse_tray_icons">Skjul _ikoner i systemstatusfeltet</s:String>
     <s:String x:Key="customize">_Tilpass...</s:String>
     <s:String x:Key="show_input_language">Vis inndataspråket</s:String>

--- a/RetroBar/Languages/Suomi.xaml
+++ b/RetroBar/Languages/Suomi.xaml
@@ -31,6 +31,7 @@
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_Salli fontin pehmennys</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Salli fontin pehmennys _valikoissa</s:String>
+    <s:String x:Key="crisp_start_button_icon">_Terävä Käynnistä-painikkeen kuvake</s:String>
     <s:String x:Key="collapse_tray_icons">Piilota _ilmoitusalueen kuvakkeet</s:String>
     <s:String x:Key="customize">_Mukauta...</s:String>
     <s:String x:Key="show_input_language">Näytä syötteen _kieli</s:String>

--- a/RetroBar/Languages/Tiếng Việt.xaml
+++ b/RetroBar/Languages/Tiếng Việt.xaml
@@ -25,6 +25,7 @@
     <s:String x:Key="taskbar_width">Độ dài thanh tác vụ:</s:String>
     <s:String x:Key="allow_font_smoothing">_Cho phép làm mượt phông chữ</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Cho phép làm mượt phông chữ trong _menu</s:String>
+    <s:String x:Key="crisp_start_button_icon">_Biểu tượng nút bắt đầu sắc nét</s:String>
     <s:String x:Key="collapse_tray_icons">_Thu gọn các biểu tượng ở phần thông báo</s:String>
     <s:String x:Key="customize">Tùy chỉnh...</s:String>
     <s:String x:Key="show_input_language">Hiển thị _ngôn ngữ nhập liệu</s:String>

--- a/RetroBar/Languages/Türkçe.xaml
+++ b/RetroBar/Languages/Türkçe.xaml
@@ -25,6 +25,7 @@
     <s:String x:Key="taskbar_width">Görev çubuğu genişliği:</s:String>
     <s:String x:Key="allow_font_smoothing">_Yazı tipi yumuşatmaya izin ver</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Menülerde yazı tipi yumuşatmaya _izin ver</s:String>
+    <s:String x:Key="crisp_start_button_icon">_Net başlat düğmesi simgesi</s:String>
     <s:String x:Key="collapse_tray_icons">Bildirim _alanı simgelerini daralt</s:String>
     <s:String x:Key="customize">_Özelleştir...</s:String>
     <s:String x:Key="show_input_language">Kla_vye düzenini göster</s:String>

--- a/RetroBar/Languages/català.xaml
+++ b/RetroBar/Languages/català.xaml
@@ -25,6 +25,7 @@
     <s:String x:Key="taskbar_width">_Amplada de la barra de tasques:</s:String>
     <s:String x:Key="allow_font_smoothing">Permet el _suavitzat dels tipus de lletra</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Permet _el suavitzat dels tipus de lletra als menús</s:String>
+    <s:String x:Key="crisp_start_button_icon">Icona nítida del _botó d'inici</s:String>
     <s:String x:Key="collapse_tray_icons">Oculta les icones de _notificació</s:String>
     <s:String x:Key="customize">_Personalització...</s:String>
     <s:String x:Key="show_input_language">Mostra la _llengua d'entrada</s:String>

--- a/RetroBar/Languages/español.xaml
+++ b/RetroBar/Languages/español.xaml
@@ -25,6 +25,7 @@
     <s:String x:Key="taskbar_width">_Ancho de la barra de tareas:</s:String>
     <s:String x:Key="allow_font_smoothing">Permitir suavizado de _fuentes</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Permitir suavizado de fuentes en los _menús</s:String>
+    <s:String x:Key="crisp_start_button_icon">Icono nítid_o del botón de inicio</s:String>
     <s:String x:Key="collapse_tray_icons">Ocultar _iconos de notificación</s:String>
     <s:String x:Key="customize">_Personalizar...</s:String>
     <s:String x:Key="show_input_language">Mostrar el idioma de _entrada</s:String>

--- a/RetroBar/Languages/euskara.xaml
+++ b/RetroBar/Languages/euskara.xaml
@@ -22,6 +22,7 @@
     </x:Array>
     <s:String x:Key="allow_font_smoothing">Onartu _letra leuntzea</s:String>
     <s:String x:Key="allow_font_smoothing_menu">_Onartu letra leuntzea menuetan</s:String>
+    <s:String x:Key="crisp_start_button_icon">Hasiera _botoiaren ikono zorrotza</s:String>
     <s:String x:Key="collapse_tray_icons">Ezkutatu jakinarazpen _ikonoak</s:String>
     <s:String x:Key="customize">_Personalizatu...</s:String>
     <s:String x:Key="show_clock">Erakutsi _erlojua</s:String>

--- a/RetroBar/Languages/français.xaml
+++ b/RetroBar/Languages/français.xaml
@@ -25,6 +25,7 @@
     <s:String x:Key="taskbar_width">Large_ur de la barre des tâches:</s:String>
     <s:String x:Key="allow_font_smoothing">_Autoriser le lissage des polices</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Autoriser _le lissage des polices dans les menus</s:String>
+    <s:String x:Key="crisp_start_button_icon">Icône _nette du bouton de démarrage</s:String>
     <s:String x:Key="collapse_tray_icons">_Réduire les icônes de la zone de notification</s:String>
     <s:String x:Key="customize">_Personaliser...</s:String>
     <s:String x:Key="show_input_language">Afficher l'indicateur de la langue d'_entrée</s:String>

--- a/RetroBar/Languages/hrvatski.xaml
+++ b/RetroBar/Languages/hrvatski.xaml
@@ -25,6 +25,7 @@
     <s:String x:Key="taskbar_width">Širina_ programske trake:</s:String>
     <s:String x:Key="allow_font_smoothing">_Dopusti izglađivanje fonta</s:String>
     <s:String x:Key="allow_font_smoothing_menu">_Dopusti izglađivanje fonta u izbornicima</s:String>
+    <s:String x:Key="crisp_start_button_icon">_Oštra ikona gumba Start</s:String>
     <s:String x:Key="collapse_tray_icons">Sakriji neaktivne ikone</s:String>
     <s:String x:Key="customize">Prilagod_i...</s:String>
     <s:String x:Key="show_input_language">Prikaži raspored _tipkovnice</s:String>

--- a/RetroBar/Languages/italiano.xaml
+++ b/RetroBar/Languages/italiano.xaml
@@ -19,6 +19,7 @@
     </x:Array>
     <s:String x:Key="allow_font_smoothing">Consenti anti-alia_sing caratteri</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Consenti anti-aliasing caratteri _nei menu</s:String>
+    <s:String x:Key="crisp_start_button_icon">Icona _del pulsante Start nitida</s:String>
     <s:String x:Key="collapse_tray_icons">Nascondi _icone nell'area di notifica</s:String>
     <s:String x:Key="customize">Personalizz_a...</s:String>
     <s:String x:Key="show_clock">M_ostra orologio</s:String>

--- a/RetroBar/Languages/latviešu.xaml
+++ b/RetroBar/Languages/latviešu.xaml
@@ -22,6 +22,7 @@
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_Atļaut fontu izlīdzināšanu</s:String>
     <s:String x:Key="allow_font_smoothing_menu">_Atļaut fontu izlīdzināšanu izvēlnēs</s:String>
+    <s:String x:Key="crisp_start_button_icon">Asa Start _taustiņa ikona</s:String>
     <s:String x:Key="collapse_tray_icons">Sakļaut pazi_ņojumu apgabala ikonas</s:String>
     <s:String x:Key="customize">_Pielāgot...</s:String>
     <s:String x:Key="show_clock">Parādiet pul_ksteni</s:String>

--- a/RetroBar/Languages/lietuvių.xaml
+++ b/RetroBar/Languages/lietuvių.xaml
@@ -21,6 +21,7 @@
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_Leisti šriftų sulyginimą</s:String>
     <s:String x:Key="allow_font_smoothing_menu">_Leisti šriftų sulyginimą meniu</s:String>
+    <s:String x:Key="crisp_start_button_icon">_Aiški Start mygtuko piktograma</s:String>
     <s:String x:Key="collapse_tray_icons">Sutra_ukti pranešimų srities piktogramas</s:String>
     <s:String x:Key="customize">_Tinkinti...</s:String>
     <s:String x:Key="show_clock">Rodyti lai_krodį</s:String>

--- a/RetroBar/Languages/magyar.xaml
+++ b/RetroBar/Languages/magyar.xaml
@@ -20,6 +20,7 @@
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_Betűsimítás engedélyezése</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Betűsimítás _engedélyezése a menükben</s:String>
+    <s:String x:Key="crisp_start_button_icon">Éles Start _gomb ikon</s:String>
     <s:String x:Key="collapse_tray_icons">Az _értesítési terület ikonjainak összecsukása</s:String>
     <s:String x:Key="show_clock">Mutasd az _órát</s:String>
     <s:String x:Key="show_multi_mon">Megjelenítés _több kijelzőn</s:String>

--- a/RetroBar/Languages/polski.xaml
+++ b/RetroBar/Languages/polski.xaml
@@ -25,6 +25,7 @@
     <s:String x:Key="taskbar_width">Szerokość paska zadań:</s:String>	
     <s:String x:Key="allow_font_smoothing">_Zezwól na wygładzanie czcionek</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Zezwól na wygładzanie czcionek w _menu</s:String>
+    <s:String x:Key="crisp_start_button_icon">Wyraźna ikona przycisku _Start</s:String>
     <s:String x:Key="collapse_tray_icons">Zwiń ikony w pasku powiadomień</s:String>
     <s:String x:Key="customize">_Dostosuj...</s:String>
     <s:String x:Key="show_input_language">Pokaż ję_zyk wprowadzania</s:String>

--- a/RetroBar/Languages/português.xaml
+++ b/RetroBar/Languages/português.xaml
@@ -25,6 +25,7 @@
     <s:String x:Key="taskbar_width">Lar_gura da barra de tarefas:</s:String>
     <s:String x:Key="allow_font_smoothing">Permitir s_uavização de fonte</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Permitir _suavização de fonte nos menus</s:String>
+    <s:String x:Key="crisp_start_button_icon">Ícone _nítido do botão Iniciar</s:String>
     <s:String x:Key="collapse_tray_icons">Ocultar ícones _inativos</s:String>
     <s:String x:Key="customize">_Personalizar...</s:String>
     <s:String x:Key="show_input_language">Mostrar o i_dioma de entrada</s:String>

--- a/RetroBar/Languages/română.xaml
+++ b/RetroBar/Languages/română.xaml
@@ -25,6 +25,7 @@
     <s:String x:Key="taskbar_width">Lățime_a barei de activități:</s:String>
     <s:String x:Key="allow_font_smoothing">Activați _netezirea fontului</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Activați netezirea fontului în _meniuri</s:String>
+    <s:String x:Key="crisp_start_button_icon">Pictogramă _nitidă pentru butonul Start</s:String>
     <s:String x:Key="collapse_tray_icons">_Ascundeți pictogramele din bara de notificări</s:String>
     <s:String x:Key="customize">_Personalizați...</s:String>
     <s:String x:Key="show_input_language">Afișați limba de _introducere</s:String>

--- a/RetroBar/Languages/slovenčina.xaml
+++ b/RetroBar/Languages/slovenčina.xaml
@@ -22,6 +22,7 @@
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_Povoliť vyhladzovanie textu</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Povo_liť vyhladzovanie textu v ponukách</s:String>
+    <s:String x:Key="crisp_start_button_icon">Ostrá ikona tlačidla _štart</s:String>
     <s:String x:Key="collapse_tray_icons">Skryť upozornenia</s:String>
     <s:String x:Key="customize">_Prispôsobiť...</s:String>
     <s:String x:Key="show_clock">Zobraziť _hodiny</s:String>

--- a/RetroBar/Languages/srpski.xaml
+++ b/RetroBar/Languages/srpski.xaml
@@ -26,6 +26,7 @@
     <s:String x:Key="taskbar_width">Širina tra_ke zadataka:</s:String>
     <s:String x:Key="allow_font_smoothing">Dozvoli izglađivanje _fontova</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Dozvoli izglađivanje fontova u _menijima</s:String>
+    <s:String x:Key="crisp_start_button_icon">_Oštra ikonica dugmeta start</s:String>
     <s:String x:Key="collapse_tray_icons">Skupi _ikonice u sistemskoj paleti</s:String>
     <s:String x:Key="customize">Prilago_di...</s:String>
     <s:String x:Key="show_input_language">Prikaži _jezik unosa</s:String>

--- a/RetroBar/Languages/svenska.xaml
+++ b/RetroBar/Languages/svenska.xaml
@@ -21,6 +21,7 @@
     </x:Array>
     <s:String x:Key="allow_font_smoothing">Tillåt t_ypsnittsutjämning</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Tillåt t_ypsnittsutjämning i menyer</s:String>
+    <s:String x:Key="crisp_start_button_icon">S_karp startknappsikon</s:String>
     <s:String x:Key="collapse_tray_icons">Kollaps meddela_ndefältet ikoner</s:String>
     <s:String x:Key="customize">Anpa_ssa...</s:String>
     <s:String x:Key="show_clock">Visa _klockan</s:String>

--- a/RetroBar/Languages/íslenska.xaml
+++ b/RetroBar/Languages/íslenska.xaml
@@ -25,6 +25,7 @@
     <s:String x:Key="taskbar_width">Breid_d verkstikunnar:</s:String>
     <s:String x:Key="allow_font_smoothing">_Leyfa letursléttun</s:String>
     <s:String x:Key="allow_font_smoothing_menu">_Leyfa letursléttun í valmyndum</s:String>
+    <s:String x:Key="crisp_start_button_icon">Skörp Start-_takkamynd</s:String>
     <s:String x:Key="collapse_tray_icons">Fela _táknin í tilkynningarsvæðinu</s:String>
     <s:String x:Key="customize">_Aðlaga...</s:String>
     <s:String x:Key="show_input_language">Sýna inntaksmálið</s:String>

--- a/RetroBar/Languages/čeština.xaml
+++ b/RetroBar/Languages/čeština.xaml
@@ -22,6 +22,7 @@
     </x:Array>
     <s:String x:Key="allow_font_smoothing">Povolit vyhlazovaní _textu</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Povolit vyhlazování textu v _nabídkách</s:String>
+    <s:String x:Key="crisp_start_button_icon">Ostrá ikona tlačítka _Start</s:String>
     <s:String x:Key="collapse_tray_icons">Skrýt upozornění</s:String>
     <s:String x:Key="customize">_Přizspůsobit...</s:String>
     <s:String x:Key="show_clock">Zobrazit _hodiny</s:String>

--- a/RetroBar/Languages/ελληνικά.xaml
+++ b/RetroBar/Languages/ελληνικά.xaml
@@ -22,6 +22,7 @@
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_Επιτροπή εξομάλυσης της γραμματοσειράς</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Εξομάλυνση γραμματοσειράς στα _μενού</s:String>
+    <s:String x:Key="crisp_start_button_icon">Ευκρινές εικονίδιο _κουμπιού έναρξης</s:String>
     <s:String x:Key="collapse_tray_icons">Απόκρ_υψη εικονιδίων περιοχής ειδοποιήσεων</s:String>
     <s:String x:Key="customize">Πρ_οσαρμογή...</s:String>
     <s:String x:Key="show_clock">Εμφάνιση του ρο_λογιού</s:String>

--- a/RetroBar/Languages/беларуская.xaml
+++ b/RetroBar/Languages/беларуская.xaml
@@ -25,6 +25,7 @@
     <s:String x:Key="taskbar_width">Шырыня панэлі задач:</s:String>
     <s:String x:Key="allow_font_smoothing">Дазволіць згладжванне шрыфтоў</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Дазволіць згладжванне шрыфтоў у _меню</s:String>
+    <s:String x:Key="crisp_start_button_icon">_Выразны значок кнопкі Пуск</s:String>
     <s:String x:Key="collapse_tray_icons">Згарнуць значкі вобласьці апавяшчэньняў</s:String>
     <s:String x:Key="customize">_Наладзіць...</s:String>
     <s:String x:Key="show_input_language">Паказваць раскладку клавіятуры</s:String>

--- a/RetroBar/Languages/български.xaml
+++ b/RetroBar/Languages/български.xaml
@@ -22,6 +22,7 @@
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_Позволи изглаждането на шрифтовете</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Позволи изглаждането на шрифтовете в _менютата</s:String>
+    <s:String x:Key="crisp_start_button_icon">_Ясна икона на бутона Старт</s:String>
     <s:String x:Key="collapse_tray_icons">Събери и_коните в района на известията</s:String>
     <s:String x:Key="customize">Персонали_зирай...</s:String>
     <s:String x:Key="show_clock">Показвай _часовника</s:String>

--- a/RetroBar/Languages/русский.xaml
+++ b/RetroBar/Languages/русский.xaml
@@ -25,6 +25,7 @@
     <s:String x:Key="taskbar_width">_Ширина панели задач:</s:String>
     <s:String x:Key="allow_font_smoothing">Пр_именять сглаживание шрифтов</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Применять сглаживание шрифтов в _меню</s:String>
+    <s:String x:Key="crisp_start_button_icon">Чёткий _значок кнопки Пуск</s:String>
     <s:String x:Key="collapse_tray_icons">Скр_ывать неиспользуемые значки</s:String>
     <s:String x:Key="customize">_Настроить...</s:String>
     <s:String x:Key="show_input_language">Отображать раскладку _клавиатуры</s:String>

--- a/RetroBar/Languages/српски.xaml
+++ b/RetroBar/Languages/српски.xaml
@@ -26,6 +26,7 @@
     <s:String x:Key="taskbar_width">Ширина тра_ке задатака:</s:String>
     <s:String x:Key="allow_font_smoothing">Дозволи изглађивање _фонтова</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Дозволи изглађивање фонтова у _менијима</s:String>
+    <s:String x:Key="crisp_start_button_icon">_Оштра иконица дугмета Старт</s:String>
     <s:String x:Key="collapse_tray_icons">Скупи _иконице у системској палети</s:String>
     <s:String x:Key="customize">Прилаго_ди...</s:String>
     <s:String x:Key="show_input_language">Прикажи _језик уноса</s:String>

--- a/RetroBar/Languages/українська.xaml
+++ b/RetroBar/Languages/українська.xaml
@@ -25,6 +25,7 @@
     <s:String x:Key="taskbar_width">Ширина панелі завдань:</s:String>
     <s:String x:Key="allow_font_smoothing">Дозволити згладжування шрифтів</s:String>
     <s:String x:Key="allow_font_smoothing_menu">Дозволити згладжування шрифтів у _меню</s:String>
+    <s:String x:Key="crisp_start_button_icon">_Чітка іконка кнопки Пуск</s:String>
     <s:String x:Key="collapse_tray_icons">При_ховувати невикористовувані значки</s:String>
     <s:String x:Key="customize">_Налаштувати...</s:String>
     <s:String x:Key="show_input_language">Показати мову введення</s:String>

--- a/RetroBar/Languages/עברית.xaml
+++ b/RetroBar/Languages/עברית.xaml
@@ -24,6 +24,7 @@
     <s:String x:Key="rowcount_tip">מספר השורות בשורת המשימות כאשר למעלה או למטה.</s:String>
     <s:String x:Key="allow_font_smoothing">_אפשר החלקת גופנים</s:String>
     <s:String x:Key="allow_font_smoothing_menu">אפשר החלקת גופנים ב_תפריטים</s:String>
+    <s:String x:Key="crisp_start_button_icon">_סמל חד ללחצן התחל</s:String>
     <s:String x:Key="collapse_tray_icons">סמלי אזור הודעה מכווץ</s:String>
     <s:String x:Key="customize">התא_מה אישית...</s:String>
     <s:String x:Key="show_clock">הצג את שעון המערכת</s:String>

--- a/RetroBar/Languages/العربية.xaml
+++ b/RetroBar/Languages/العربية.xaml
@@ -25,6 +25,7 @@
     <s:String x:Key="taskbar_width">ع_رض شريط المهام:</s:String>
     <s:String x:Key="allow_font_smoothing">السماح بتنعيم ال_خطوط</s:String>
     <s:String x:Key="allow_font_smoothing_menu">السماح بتنعيم الخطوط في ال_قوائم</s:String>
+    <s:String x:Key="crisp_start_button_icon">أيقونة زر ابدأ _واضحة</s:String>
     <s:String x:Key="collapse_tray_icons">طيّ أيقونات _منطقة الإعلام</s:String>
     <s:String x:Key="customize">_تخصيص...</s:String>
     <s:String x:Key="show_input_language">إظهار لغة الإد_خال</s:String>

--- a/RetroBar/Languages/فارسی.xaml
+++ b/RetroBar/Languages/فارسی.xaml
@@ -22,6 +22,7 @@
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_صاف‌سازی فونت</s:String>
     <s:String x:Key="allow_font_smoothing_menu">صاف‌سازی فونت در _منوها</s:String>
+    <s:String x:Key="crisp_start_button_icon">نماد _واضح دکمه شروع</s:String>
     <s:String x:Key="collapse_tray_icons">آیکون‌ها در منطقه اعلان‌ها جمع شوند</s:String>
     <s:String x:Key="customize">سفارشی‌سازی</s:String>
     <s:String x:Key="show_clock">نمایش ساعت</s:String>

--- a/RetroBar/Languages/ไทย.xaml
+++ b/RetroBar/Languages/ไทย.xaml
@@ -22,6 +22,7 @@
     </x:Array>
     <s:String x:Key="allow_font_smoothing">_ใช้การปรับตัวอักษรให้คมชัด</s:String>
     <s:String x:Key="allow_font_smoothing_menu">_ใช้การปรับตัวอักษรให้คมชัดในเมนู</s:String>
+    <s:String x:Key="crisp_start_button_icon">ไอคอนปุ่ม Start _คมชัด</s:String>
     <s:String x:Key="collapse_tray_icons">ยุบไอคอนใน_พื้นที่แจ้งเตือน</s:String>
     <s:String x:Key="customize">_ปรับแต่ง...</s:String>
     <s:String x:Key="show_clock">แสดง_นาฬิกา</s:String>

--- a/RetroBar/Languages/中文(简体).xaml
+++ b/RetroBar/Languages/中文(简体).xaml
@@ -25,6 +25,7 @@
     <s:String x:Key="taskbar_width">任务栏宽度(_W): </s:String>
     <s:String x:Key="allow_font_smoothing">允许字体平滑(_A)</s:String>
     <s:String x:Key="allow_font_smoothing_menu">允许菜单中的字体平滑(_A)</s:String>
+    <s:String x:Key="crisp_start_button_icon">清晰的开始按钮图标(_B)</s:String>
     <s:String x:Key="collapse_tray_icons">收起通知区域图标(_N)</s:String>
     <s:String x:Key="customize">自定义(_C)...</s:String>
     <s:String x:Key="show_input_language">显示输入语言(_L)</s:String>

--- a/RetroBar/Languages/中文(繁體).xaml
+++ b/RetroBar/Languages/中文(繁體).xaml
@@ -22,6 +22,7 @@
     </x:Array>
     <s:String x:Key="allow_font_smoothing">允許字體平滑(_A)</s:String>
     <s:String x:Key="allow_font_smoothing_menu">允許選單中的字體平滑(_A)</s:String>
+    <s:String x:Key="crisp_start_button_icon">清晰的開始按鈕圖示(_B)</s:String>
     <s:String x:Key="collapse_tray_icons">隱藏非使用中時圖示(_N)</s:String>
     <s:String x:Key="customize">自訂(_E)...</s:String>
     <s:String x:Key="show_input_language">顯示語言列</s:String>

--- a/RetroBar/Languages/日本語.xaml
+++ b/RetroBar/Languages/日本語.xaml
@@ -25,6 +25,7 @@
     <s:String x:Key="taskbar_width">タスクバーの幅(_W)：</s:String>
     <s:String x:Key="allow_font_smoothing">フォントをなめらかにする(_A)</s:String>
     <s:String x:Key="allow_font_smoothing_menu">メニューのフォントをなめらかにする(_A)</s:String>
+    <s:String x:Key="crisp_start_button_icon">スタートボタンのアイコンを鮮明にする(_B)</s:String>
     <s:String x:Key="collapse_tray_icons">通知領域のアイコンを折りたたむ(_N)</s:String>
     <s:String x:Key="customize">カスタマイズ(_C)...</s:String>
     <s:String x:Key="show_input_language">表示入力言語(_L)</s:String>

--- a/RetroBar/Languages/한국어.xaml
+++ b/RetroBar/Languages/한국어.xaml
@@ -22,6 +22,7 @@
     </x:Array>
     <s:String x:Key="allow_font_smoothing">폰트 스무딩 활성화(_S)</s:String>
     <s:String x:Key="allow_font_smoothing_menu">메뉴에서 폰트 스무딩 활성화(_A)</s:String>
+    <s:String x:Key="crisp_start_button_icon">선명한 시작 단추 아이콘(_B)</s:String>
     <s:String x:Key="collapse_tray_icons">사용하지 않은 아이콘 숨기기(_H)</s:String>
     <s:String x:Key="customize">사용자 지정(_C)...</s:String>
     <s:String x:Key="show_clock">시계 표시(_K)</s:String>

--- a/RetroBar/PropertiesWindow.xaml
+++ b/RetroBar/PropertiesWindow.xaml
@@ -380,6 +380,10 @@
                                   IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=AllowFontSmoothingMenu, UpdateSourceTrigger=PropertyChanged}">
                             <Label Content="{DynamicResource allow_font_smoothing_menu}" />
                         </CheckBox>
+                        <CheckBox x:Name="cbCrispStartButtonIcon"
+                                  IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=CrispStartButtonIcon, UpdateSourceTrigger=PropertyChanged}">
+                            <Label Content="{DynamicResource crisp_start_button_icon}" />
+                        </CheckBox>
                         <DockPanel>
                             <Label VerticalAlignment="Center"
                                    Target="{Binding ElementName=cboWinNumHotkeysAction}">

--- a/RetroBar/Themes/System.xaml
+++ b/RetroBar/Themes/System.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:system="clr-namespace:System;assembly=mscorlib">
+                    xmlns:system="clr-namespace:System;assembly=mscorlib"
+                    xmlns:utilities="clr-namespace:RetroBar.Utilities">
 
     <system:Double x:Key="TaskbarHeight">28</system:Double>
     <system:Double x:Key="TaskbarRowHeight">25</system:Double>
@@ -807,6 +808,17 @@
                 Value="0,0,2,0" />
         <Setter Property="Source"
                 Value="{DynamicResource StartIconImage}" />
+        <Style.Triggers>
+            <!-- The start icons are small bitmaps shown at their native size, so on integer
+                 display scales (e.g. 200%) nearest-neighbor keeps the pixels sharp instead of
+                 letting the default filter blur them and muddy the colors. Opt-out via setting
+                 since it can look uneven on fractional scales. -->
+            <DataTrigger Binding="{Binding Source={x:Static utilities:Settings.Instance}, Path=CrispStartButtonIcon}"
+                         Value="True">
+                <Setter Property="RenderOptions.BitmapScalingMode"
+                        Value="NearestNeighbor" />
+            </DataTrigger>
+        </Style.Triggers>
     </Style>
 
     <Style TargetType="Image"

--- a/RetroBar/Utilities/Settings.cs
+++ b/RetroBar/Utilities/Settings.cs
@@ -199,6 +199,13 @@ namespace RetroBar.Utilities
             set => Set(ref _allowFontSmoothingMenu, value);
         }
 
+        private bool _crispStartButtonIcon = true;
+        public bool CrispStartButtonIcon
+        {
+            get => _crispStartButtonIcon;
+            set => Set(ref _crispStartButtonIcon, value);
+        }
+
         private bool _useSoftwareRendering = false;
         public bool UseSoftwareRendering
         {


### PR DESCRIPTION
On my mission to add more crispy graphics for scaled UI, here is the latest change.

---

The classic-theme start button icons (start9x, startvistaclassic, startxpclassic, startxpblue) are small bitmaps shown at their native size. At integer display scales (e.g. 200%) WPF's default scaling filter blurred them and muddied their colors.

Render them with nearest-neighbor scaling so they stay sharp, controlled by a "Crisp start button icon" checkbox on the Advanced tab (on by default). The StartIcon style sets BitmapScalingMode=NearestNeighbor via a trigger bound to the setting, so it can be disabled on fractional scales where nearest-neighbor can look uneven.

Add localized labels for all bundled languages, each with an access key that is unique within that language's Advanced tab.

---

<img width="336" height="238" alt="image" src="https://github.com/user-attachments/assets/9a056507-af03-4813-94c0-3941e07bc9de" />
