### PR TITLE
Fix RetroBar ignoring DPI changes on Windows 11

### DIFF
--- a/RetroBar/RetroBar.csproj
+++ b/RetroBar/RetroBar.csproj
@@ -41,7 +41,7 @@
 
   <ItemGroup>
     <PackageReference Include="gong-wpf-dragdrop" Version="3.1.1" />
-    <PackageReference Include="ManagedShell" Version="0.0.344" />
+    <PackageReference Include="ManagedShell" Version="0.0.346" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates ManagedShell to pick up the fix for #151. This is a workaround for a Windows 11 bug, and the tradeoff is that RetroBar will show in Task Manager's window listing in Windows 11. Hopefully this will be temporary 🤞 