### PR TITLE
Enable HW acceleration over RDP on .NET 10

### DIFF
--- a/RetroBar/RetroBar.csproj
+++ b/RetroBar/RetroBar.csproj
@@ -15,6 +15,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+	<RuntimeHostConfigurationOption Include="Switch.System.Windows.Media.EnableHardwareAccelerationInRdp" Value="true" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="Resources\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <SubType>Designer</SubType>


### PR DESCRIPTION
Now that we support .NET 10, we can take advantage of the new RDP hardware acceleration support.