### PR TITLE
Fix floating start going under after leaving fullscreen

### DIFF
--- a/RetroBar/Controls/StartButton.xaml.cs
+++ b/RetroBar/Controls/StartButton.xaml.cs
@@ -280,6 +280,13 @@ namespace RetroBar.Controls
             floatingStartButton.SetPosition(getButtonRect());
         }
 
+        public void UpdateFloatingStartTopmost(bool topmost)
+        {
+            if (floatingStartButton == null) return;
+
+            floatingStartButton.Topmost = topmost;
+        }
+
         #endregion
     }
 }

--- a/RetroBar/Taskbar.xaml.cs
+++ b/RetroBar/Taskbar.xaml.cs
@@ -328,6 +328,18 @@ namespace RetroBar
                 OnPropertyChanged(nameof(Opacity));
             }
         }
+
+        protected override void OnFullScreenEnter(FullScreenApp app)
+        {
+            base.OnFullScreenEnter(app);
+            StartButton?.UpdateFloatingStartTopmost(false);
+        }
+
+        protected override void OnFullScreenLeave()
+        {
+            base.OnFullScreenLeave();
+            StartButton?.UpdateFloatingStartTopmost(true);
+        }
         #endregion
 
         #region Taskbar events


### PR DESCRIPTION
Fixes the floating start button (i.e. Vista start orb) going below windows after the following series of events:

1. RetroBar is set to a theme with no floating start button.
2. RetroBar theme is changed to Windows Vista Aero.
3. Firefox enters full-screen.
4. Firefox leaves full-screen.