### PR TITLE
Update ManagedShell

### DIFF
--- a/RetroBar/RetroBar.csproj
+++ b/RetroBar/RetroBar.csproj
@@ -45,7 +45,7 @@
 
   <ItemGroup>
     <PackageReference Include="gong-wpf-dragdrop" Version="3.1.1" />
-    <PackageReference Include="ManagedShell" Version="0.0.355" />
+    <PackageReference Include="ManagedShell" Version="0.0.358" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #1439
Disables Win11 DPI workaround by default to avoid zorder bugs