### PR TITLE
Show pressed state on correct Start button with WinKey on multiple monitors

### DIFF
--- a/RetroBar/Controls/StartButton.xaml.cs
+++ b/RetroBar/Controls/StartButton.xaml.cs
@@ -165,7 +165,9 @@ namespace RetroBar.Controls
 
         private void AppVisibilityHelper_StartMenuVisibilityChanged(object? sender, StartMenuMonitor.StartMenuMonitorEventArgs e)
         {
-            if (e.Visible && e.TaskbarHwndActivated != IntPtr.Zero && Host != null && e.TaskbarHwndActivated != Host.Handle)
+            if (e.Visible && Host != null &&
+                ((e.TaskbarHwndActivated != IntPtr.Zero && e.TaskbarHwndActivated != Host.Handle) ||
+                (e.StartHmonitor != IntPtr.Zero && e.StartHmonitor != Host.Screen.HMonitor)))
             {
                 // Only set as visible when activated from our taskbar
                 return;

--- a/RetroBar/Utilities/StartMenuMonitor.cs
+++ b/RetroBar/Utilities/StartMenuMonitor.cs
@@ -44,16 +44,20 @@ namespace RetroBar.Utilities
         private void poller_Tick(object sender, EventArgs e)
         {
             bool newIsVisible = false;
+            IntPtr startHmonitor = IntPtr.Zero;
+
             if (EnvironmentHelper.IsWindows8OrBetter && isModernStartMenuOpen())
             {
                 // Windows 8+
                 newIsVisible = true;
+                startHmonitor = hMonitorModernStartMenu();
             }
 
             if (!newIsVisible && isClassicStartMenuOpen())
             {
                 // Windows 7, StartIsBack, Start8+
                 newIsVisible = true;
+                startHmonitor = hMonitorClassicStartMenu();
             }
 
             if (!newIsVisible && isOpenShellMenuOpen())
@@ -61,12 +65,13 @@ namespace RetroBar.Utilities
                 // Open Shell Menu
                 newIsVisible = true;
                 relocateStartMenuByClass("OpenShell.CMenuContainer");
+                startHmonitor = hMonitorOpenShellMenu();
             }
 
-            setVisibility(newIsVisible);
+            setVisibility(newIsVisible, startHmonitor);
         }
 
-        private void setVisibility(bool isVisible)
+        private void setVisibility(bool isVisible, IntPtr startHmonitor)
         {
             if (isVisible == _isVisible)
             {
@@ -78,7 +83,8 @@ namespace RetroBar.Utilities
             StartMenuMonitorEventArgs args = new StartMenuMonitorEventArgs
             {
                 Visible = _isVisible,
-                TaskbarHwndActivated = _taskbarHwndActivated
+                TaskbarHwndActivated = _taskbarHwndActivated,
+                StartHmonitor = startHmonitor
             };
 
             StartMenuVisibilityChanged?.Invoke(this, args);
@@ -122,6 +128,33 @@ namespace RetroBar.Utilities
             }
 
             return IsWindowVisible(hStartMenu);
+        }
+
+        private IntPtr hMonitorModernStartMenu()
+        {
+            return hMonitorByClass("Windows.UI.Core.CoreWindow", "Start");
+        }
+
+        private IntPtr hMonitorClassicStartMenu()
+        {
+            return hMonitorByClass("DV2ControlHost");
+        }
+
+        private IntPtr hMonitorOpenShellMenu()
+        {
+            return hMonitorByClass("OpenShell.CMenuContainer");
+        }
+
+        private IntPtr hMonitorByClass(string className, string title = "")
+        {
+            IntPtr hStartMenu = title.Length > 0 ? FindWindow(className, title) : FindWindowEx(IntPtr.Zero, IntPtr.Zero, className, IntPtr.Zero);
+
+            if (hStartMenu == IntPtr.Zero)
+            {
+                return IntPtr.Zero;
+            }
+
+            return MonitorFromWindow(hStartMenu, MONITOR_DEFAULTTONEAREST);
         }
 
         private void relocateStartMenuByClass(string className)
@@ -440,6 +473,7 @@ namespace RetroBar.Utilities
         public class StartMenuMonitorEventArgs : LauncherVisibilityEventArgs
         {
             public IntPtr TaskbarHwndActivated;
+            public IntPtr StartHmonitor;
         }
     }
 }

--- a/RetroBar/Utilities/StartMenuMonitor.cs
+++ b/RetroBar/Utilities/StartMenuMonitor.cs
@@ -1,12 +1,13 @@
-﻿using System;
-using System.Runtime.InteropServices;
-using System.Windows;
-using System.Windows.Threading;
-using ManagedShell.AppBar;
+﻿using ManagedShell.AppBar;
 using ManagedShell.Common.Helpers;
 using ManagedShell.Common.Logging;
 using ManagedShell.Common.SupportingClasses;
 using ManagedShell.UWPInterop;
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Windows;
+using System.Windows.Threading;
 using static ManagedShell.Interop.NativeMethods;
 
 namespace RetroBar.Utilities
@@ -132,7 +133,14 @@ namespace RetroBar.Utilities
 
         private IntPtr hMonitorModernStartMenu()
         {
-            return hMonitorByClass("Windows.UI.Core.CoreWindow", "Start");
+            IntPtr hwndForeground = GetForegroundWindow();
+            StringBuilder cName = new StringBuilder(256);
+            GetClassName(hwndForeground, cName, cName.Capacity);
+            if (cName.ToString() == "Windows.UI.Core.CoreWindow")
+            {
+                return MonitorFromWindow(hwndForeground, MONITOR_DEFAULTTONEAREST);
+            }
+            return IntPtr.Zero;
         }
 
         private IntPtr hMonitorClassicStartMenu()

--- a/RetroBar/Utilities/StartMenuMonitor.cs
+++ b/RetroBar/Utilities/StartMenuMonitor.cs
@@ -138,6 +138,7 @@ namespace RetroBar.Utilities
             GetClassName(hwndForeground, cName, cName.Capacity);
             if (cName.ToString() == "Windows.UI.Core.CoreWindow")
             {
+                // When the modern Start menu opens, it gains focus, so this is probably it
                 return MonitorFromWindow(hwndForeground, MONITOR_DEFAULTTONEAREST);
             }
             return IntPtr.Zero;
@@ -153,9 +154,9 @@ namespace RetroBar.Utilities
             return hMonitorByClass("OpenShell.CMenuContainer");
         }
 
-        private IntPtr hMonitorByClass(string className, string title = "")
+        private IntPtr hMonitorByClass(string className)
         {
-            IntPtr hStartMenu = title.Length > 0 ? FindWindow(className, title) : FindWindowEx(IntPtr.Zero, IntPtr.Zero, className, IntPtr.Zero);
+            IntPtr hStartMenu = FindWindowEx(IntPtr.Zero, IntPtr.Zero, className, IntPtr.Zero);
 
             if (hStartMenu == IntPtr.Zero)
             {


### PR DESCRIPTION
Gets the monitor of the start menu window and passes it back to the start button control to compare against its host taskbar's monitor.